### PR TITLE
Broken link

### DIFF
--- a/content/post/2018/07/Computing-and-Caching.md
+++ b/content/post/2018/07/Computing-and-Caching.md
@@ -23,7 +23,7 @@ Today's article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare's *A Midsummer Night's Dream* tweet their own lines in our
 database in [PostgreSQL Concurrency: Data Modification
-Language](/blog/2018/06/PostgreSQL-DML.md), and having had them like a
+Language](/blog/2018/06/postgresql-concurrency-data-modification-language/), and having had them like a
 retweet a lot in [PostgreSQL Concurrency: Isolation and
 Locking](/blog/2018/07/postgresql-concurrency-isolation-and-locking/), it's
 time to think about how to display our counters in an efficient way.

--- a/content/post/2018/07/Modeling-for-Concurrency.md
+++ b/content/post/2018/07/Modeling-for-Concurrency.md
@@ -20,7 +20,7 @@ Today's article takes us a step further and builds on what we did last week,
 in particular the database modeling for a *tweet* like application. After
 having had all the characters from Shakespeare's *A Midsummer Night's Dream*
 tweet their own lines in our database in [PostgreSQL Concurrency: Data
-Modification Language](/blog/2018/06/PostgreSQL-DML.md), it's time for them
+Modification Language](/blog/2018/06/postgresql-concurrency-data-modification-language/), it's time for them
 to do some actions on the tweets: likes and retweet.
 
 Of course, we're going to put concurrency to the test, so we're going to

--- a/content/post/2018/07/PostgreSQL-Event-Based-Processing.md
+++ b/content/post/2018/07/PostgreSQL-Event-Based-Processing.md
@@ -22,7 +22,7 @@ Today's article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare's *A Midsummer Night's Dream* tweet their own lines in our
 database in [PostgreSQL Concurrency: Data Modification
-Language](/blog/2018/06/PostgreSQL-DML.md), and having had them like and
+Language](/blog/2018/06/postgresql-concurrency-data-modification-language/), and having had them like and
 retweet a lot in [PostgreSQL Concurrency: Isolation and
 Locking](/blog/2018/07/postgresql-concurrency-isolation-and-locking/), we
 saw how to manage concurrent retweets in an efficient way in [Computing and

--- a/content/post/2018/07/PostgreSQL-Isolation-Locking.md
+++ b/content/post/2018/07/PostgreSQL-Isolation-Locking.md
@@ -19,7 +19,7 @@ maintains consistency while allowing concurrent operations.
 This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
 [PostgreSQL Concurrency: Data Modification
-Language](/blog/2018/06/PostgreSQL-DML.md).
+Language](/blog/2018/06/postgresql-concurrency-data-modification-language/).
 
 <!--more-->
 <!--toc-->
@@ -155,13 +155,13 @@ progress to be included in PostgreSQL!
 # Concurrent Updates and Isolation
 
 In our *tweet* model of an application, we can have a look at handling
-*retweets*, which is a *counter* field in the *tweet.message* table. 
+*retweets*, which is a *counter* field in the *tweet.message* table.
 
 {{< alert success >}}
 
 The application model for Tweeting is introduced in the first article of
 this series:[PostgreSQL Concurrency: Data Modification
-Language](/blog/2018/06/PostgreSQL-DML.md).
+Language](/blog/2018/06/postgresql-concurrency-data-modification-language/).
 
 {{< /alert  >}}
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -163,7 +163,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -225,7 +225,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -260,7 +260,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -289,7 +289,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -704,7 +704,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -766,7 +766,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -801,7 +801,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -830,7 +830,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/archives/index.html
+++ b/docs/archives/index.html
@@ -1935,7 +1935,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1997,7 +1997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -2032,7 +2032,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -2061,7 +2061,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/1/01/index.html
+++ b/docs/blog/1/01/index.html
@@ -563,7 +563,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -625,7 +625,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -660,7 +660,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -689,7 +689,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2008/12/emacs-muse-powered-blog/index.html
+++ b/docs/blog/2008/12/emacs-muse-powered-blog/index.html
@@ -585,7 +585,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -647,7 +647,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -682,7 +682,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -711,7 +711,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2008/12/emacs-snapshot/index.html
+++ b/docs/blog/2008/12/emacs-snapshot/index.html
@@ -610,7 +610,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -672,7 +672,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -707,7 +707,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -736,7 +736,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2008/12/fake-entry/index.html
+++ b/docs/blog/2008/12/fake-entry/index.html
@@ -591,7 +591,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -653,7 +653,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -688,7 +688,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -717,7 +717,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2008/12/new-site-using-new-software/index.html
+++ b/docs/blog/2008/12/new-site-using-new-software/index.html
@@ -581,7 +581,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -643,7 +643,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -678,7 +678,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -707,7 +707,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2008/12/useful-emacs-trick/index.html
+++ b/docs/blog/2008/12/useful-emacs-trick/index.html
@@ -574,7 +574,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -636,7 +636,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -671,7 +671,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -700,7 +700,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/01/comparing-londiste-and-slony/index.html
+++ b/docs/blog/2009/01/comparing-londiste-and-slony/index.html
@@ -579,7 +579,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -641,7 +641,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -676,7 +676,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -705,7 +705,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/01/controling-hot-usage-in-8.3/index.html
+++ b/docs/blog/2009/01/controling-hot-usage-in-8.3/index.html
@@ -667,7 +667,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -729,7 +729,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -764,7 +764,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -793,7 +793,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/01/londiste-trick/index.html
+++ b/docs/blog/2009/01/londiste-trick/index.html
@@ -628,7 +628,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -690,7 +690,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -725,7 +725,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -754,7 +754,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/02/asko-oja-talks-about-skype-architecture/index.html
+++ b/docs/blog/2009/02/asko-oja-talks-about-skype-architecture/index.html
@@ -596,7 +596,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -658,7 +658,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -693,7 +693,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -722,7 +722,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/02/importing-xml-content-from-file/index.html
+++ b/docs/blog/2009/02/importing-xml-content-from-file/index.html
@@ -621,7 +621,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -683,7 +683,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -718,7 +718,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -747,7 +747,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/02/prefix-gist-index-now-in-8.1/index.html
+++ b/docs/blog/2009/02/prefix-gist-index-now-in-8.1/index.html
@@ -613,7 +613,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -675,7 +675,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -710,7 +710,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -739,7 +739,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/02/skytools-ticker-daemon-and-londiste/index.html
+++ b/docs/blog/2009/02/skytools-ticker-daemon-and-londiste/index.html
@@ -577,7 +577,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -639,7 +639,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -674,7 +674,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -703,7 +703,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/04/skytools-3.0-reaches-alpha1/index.html
+++ b/docs/blog/2009/04/skytools-3.0-reaches-alpha1/index.html
@@ -603,7 +603,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -665,7 +665,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -700,7 +700,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -729,7 +729,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/05/pgcon-2009/index.html
+++ b/docs/blog/2009/05/pgcon-2009/index.html
@@ -624,7 +624,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -721,7 +721,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -750,7 +750,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/05/prepared-statements-and-pgbouncer/index.html
+++ b/docs/blog/2009/05/prepared-statements-and-pgbouncer/index.html
@@ -625,7 +625,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -687,7 +687,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -722,7 +722,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -751,7 +751,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/06/prefix-extension-reaches-1.0-rc1/index.html
+++ b/docs/blog/2009/06/prefix-extension-reaches-1.0-rc1/index.html
@@ -601,7 +601,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -663,7 +663,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -698,7 +698,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -727,7 +727,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/07/prefix-1.0~rc2-1/index.html
+++ b/docs/blog/2009/07/prefix-1.0~rc2-1/index.html
@@ -632,7 +632,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -694,7 +694,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -729,7 +729,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -758,7 +758,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/08/hstore-new--preprepare-reach-debian-too/index.html
+++ b/docs/blog/2009/08/hstore-new--preprepare-reach-debian-too/index.html
@@ -605,7 +605,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -667,7 +667,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -702,7 +702,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -731,7 +731,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/08/prefix-1.0~rc2-in-debian-testing/index.html
+++ b/docs/blog/2009/08/prefix-1.0~rc2-in-debian-testing/index.html
@@ -624,7 +624,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -721,7 +721,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -750,7 +750,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/08/some-emacs-nifties/index.html
+++ b/docs/blog/2009/08/some-emacs-nifties/index.html
@@ -655,7 +655,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -717,7 +717,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -752,7 +752,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -781,7 +781,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/09/emacs-is-twinkling-here/index.html
+++ b/docs/blog/2009/09/emacs-is-twinkling-here/index.html
@@ -604,7 +604,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -666,7 +666,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -701,7 +701,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -730,7 +730,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/09/escreen-integration/index.html
+++ b/docs/blog/2009/09/escreen-integration/index.html
@@ -664,7 +664,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -726,7 +726,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -761,7 +761,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -790,7 +790,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/09/follow-up-on-dimmailrc-add-entry/index.html
+++ b/docs/blog/2009/09/follow-up-on-dimmailrc-add-entry/index.html
@@ -614,7 +614,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -676,7 +676,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -711,7 +711,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -740,7 +740,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/09/improving-~/.mailrc-usage/index.html
+++ b/docs/blog/2009/09/improving-~/.mailrc-usage/index.html
@@ -682,7 +682,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -744,7 +744,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -779,7 +779,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -808,7 +808,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/10/emacs-muse-based-publishing/index.html
+++ b/docs/blog/2009/10/emacs-muse-based-publishing/index.html
@@ -628,7 +628,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -690,7 +690,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -725,7 +725,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -754,7 +754,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/10/prefix-1.0.0/index.html
+++ b/docs/blog/2009/10/prefix-1.0.0/index.html
@@ -631,7 +631,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -693,7 +693,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -728,7 +728,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -757,7 +757,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/11/pgday.eu-paris-it-was-awesome/index.html
+++ b/docs/blog/2009/11/pgday.eu-paris-it-was-awesome/index.html
@@ -600,7 +600,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -697,7 +697,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -726,7 +726,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/11/prefix-1.1.0/index.html
+++ b/docs/blog/2009/11/prefix-1.1.0/index.html
@@ -620,7 +620,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -682,7 +682,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -717,7 +717,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -746,7 +746,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/11/yet-another-postgresql-tool-hits-debian/index.html
+++ b/docs/blog/2009/11/yet-another-postgresql-tool-hits-debian/index.html
@@ -742,7 +742,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -804,7 +804,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -839,7 +839,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -868,7 +868,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/12/pg_stagings-bird-view/index.html
+++ b/docs/blog/2009/12/pg_stagings-bird-view/index.html
@@ -604,7 +604,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -666,7 +666,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -701,7 +701,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -730,7 +730,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2009/12/pgday.eu-feedback/index.html
+++ b/docs/blog/2009/12/pgday.eu-feedback/index.html
@@ -700,7 +700,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -762,7 +762,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -797,7 +797,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -826,7 +826,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/02/getting-out-of-sql_ascii-part-1/index.html
+++ b/docs/blog/2010/02/getting-out-of-sql_ascii-part-1/index.html
@@ -653,7 +653,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -715,7 +715,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -750,7 +750,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -779,7 +779,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/02/getting-out-of-sql_ascii-part-2/index.html
+++ b/docs/blog/2010/02/getting-out-of-sql_ascii-part-2/index.html
@@ -801,7 +801,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -863,7 +863,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -898,7 +898,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -927,7 +927,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/02/resetting-sequences.-all-of-them-please/index.html
+++ b/docs/blog/2010/02/resetting-sequences.-all-of-them-please/index.html
@@ -637,7 +637,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -699,7 +699,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -734,7 +734,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -763,7 +763,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/03/emacs-muse-hacking/index.html
+++ b/docs/blog/2010/03/emacs-muse-hacking/index.html
@@ -616,7 +616,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -678,7 +678,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -713,7 +713,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -742,7 +742,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/03/finding-orphaned-sequences/index.html
+++ b/docs/blog/2010/03/finding-orphaned-sequences/index.html
@@ -619,7 +619,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -681,7 +681,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -716,7 +716,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -745,7 +745,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/04/import-fixed-width-data-with-pgloader/index.html
+++ b/docs/blog/2010/04/import-fixed-width-data-with-pgloader/index.html
@@ -726,7 +726,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -788,7 +788,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -823,7 +823,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -852,7 +852,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/04/pgloader-activity-report/index.html
+++ b/docs/blog/2010/04/pgloader-activity-report/index.html
@@ -660,7 +660,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -722,7 +722,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -757,7 +757,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -786,7 +786,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/05/back-from-pgcon2010/index.html
+++ b/docs/blog/2010/05/back-from-pgcon2010/index.html
@@ -789,7 +789,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -851,7 +851,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -886,7 +886,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -915,7 +915,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/back-from-char10/index.html
+++ b/docs/blog/2010/07/back-from-char10/index.html
@@ -613,7 +613,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -675,7 +675,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -710,7 +710,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -739,7 +739,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/background-writers/index.html
+++ b/docs/blog/2010/07/background-writers/index.html
@@ -637,7 +637,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -699,7 +699,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -734,7 +734,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -763,7 +763,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/clusterssh-gets-dsh-support/index.html
+++ b/docs/blog/2010/07/clusterssh-gets-dsh-support/index.html
@@ -640,7 +640,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -702,7 +702,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -737,7 +737,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -766,7 +766,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/dim-switch-window.el-fixes/index.html
+++ b/docs/blog/2010/07/dim-switch-window.el-fixes/index.html
@@ -587,7 +587,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -649,7 +649,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -684,7 +684,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -713,7 +713,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/dim-switch-window.el/index.html
+++ b/docs/blog/2010/07/dim-switch-window.el/index.html
@@ -599,7 +599,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -661,7 +661,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -696,7 +696,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -725,7 +725,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/emacs-and-postgresql/index.html
+++ b/docs/blog/2010/07/emacs-and-postgresql/index.html
@@ -651,7 +651,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -713,7 +713,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -748,7 +748,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -777,7 +777,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/logs-analysis/index.html
+++ b/docs/blog/2010/07/logs-analysis/index.html
@@ -607,7 +607,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -669,7 +669,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -704,7 +704,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -733,7 +733,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/mvcc-in-the-cloud/index.html
+++ b/docs/blog/2010/07/mvcc-in-the-cloud/index.html
@@ -637,7 +637,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -699,7 +699,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -734,7 +734,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -763,7 +763,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/partitioning-relation-size-per-group/index.html
+++ b/docs/blog/2010/07/partitioning-relation-size-per-group/index.html
@@ -688,7 +688,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -750,7 +750,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -785,7 +785,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -814,7 +814,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/07/using-indexes-as-column-store/index.html
+++ b/docs/blog/2010/07/using-indexes-as-column-store/index.html
@@ -610,7 +610,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -672,7 +672,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -707,7 +707,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -736,7 +736,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/database-virtual-machines/index.html
+++ b/docs/blog/2010/08/database-virtual-machines/index.html
@@ -599,7 +599,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -661,7 +661,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -696,7 +696,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -725,7 +725,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/debian-packaging-postgresql-extensions/index.html
+++ b/docs/blog/2010/08/debian-packaging-postgresql-extensions/index.html
@@ -689,7 +689,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -751,7 +751,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -786,7 +786,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -815,7 +815,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/editing-constants-in-constraints/index.html
+++ b/docs/blog/2010/08/editing-constants-in-constraints/index.html
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -759,7 +759,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -788,7 +788,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/el-get-and-dim-switch-window-status-update/index.html
+++ b/docs/blog/2010/08/el-get-and-dim-switch-window-status-update/index.html
@@ -655,7 +655,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -717,7 +717,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -752,7 +752,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -781,7 +781,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/el-get-news/index.html
+++ b/docs/blog/2010/08/el-get-news/index.html
@@ -660,7 +660,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -722,7 +722,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -757,7 +757,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -786,7 +786,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/el-get/index.html
+++ b/docs/blog/2010/08/el-get/index.html
@@ -706,7 +706,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -768,7 +768,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -803,7 +803,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -832,7 +832,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/happy-numbers/index.html
+++ b/docs/blog/2010/08/happy-numbers/index.html
@@ -761,7 +761,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -823,7 +823,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -858,7 +858,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -887,7 +887,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/playing-with-bit-strings/index.html
+++ b/docs/blog/2010/08/playing-with-bit-strings/index.html
@@ -660,7 +660,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -722,7 +722,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -757,7 +757,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -786,7 +786,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/querying-the-catalog-to-plan-an-upgrade/index.html
+++ b/docs/blog/2010/08/querying-the-catalog-to-plan-an-upgrade/index.html
@@ -684,7 +684,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -746,7 +746,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -781,7 +781,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -810,7 +810,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/want-to-share-your-recipes/index.html
+++ b/docs/blog/2010/08/want-to-share-your-recipes/index.html
@@ -644,7 +644,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -706,7 +706,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -741,7 +741,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -770,7 +770,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/08/welcome-el-get-scratch-installer/index.html
+++ b/docs/blog/2010/08/welcome-el-get-scratch-installer/index.html
@@ -605,7 +605,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -667,7 +667,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -702,7 +702,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -731,7 +731,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/postfix-sender_dependent_relayhost_maps/index.html
+++ b/docs/blog/2010/09/postfix-sender_dependent_relayhost_maps/index.html
@@ -652,7 +652,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -714,7 +714,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -749,7 +749,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -778,7 +778,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/regexp-performances-and-finite-automata/index.html
+++ b/docs/blog/2010/09/regexp-performances-and-finite-automata/index.html
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -736,7 +736,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -771,7 +771,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -800,7 +800,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/scratch-that-itch-m-x-mailq/index.html
+++ b/docs/blog/2010/09/scratch-that-itch-m-x-mailq/index.html
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -758,7 +758,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -793,7 +793,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -822,7 +822,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/switch-window-reaches-0.8/index.html
+++ b/docs/blog/2010/09/switch-window-reaches-0.8/index.html
@@ -608,7 +608,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -670,7 +670,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -705,7 +705,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -734,7 +734,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/synchronous-replication/index.html
+++ b/docs/blog/2010/09/synchronous-replication/index.html
@@ -673,7 +673,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -735,7 +735,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -770,7 +770,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -799,7 +799,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/window-functions-example-remix/index.html
+++ b/docs/blog/2010/09/window-functions-example-remix/index.html
@@ -615,7 +615,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -677,7 +677,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -712,7 +712,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -741,7 +741,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/09/window-functions-example/index.html
+++ b/docs/blog/2010/09/window-functions-example/index.html
@@ -638,7 +638,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -700,7 +700,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -735,7 +735,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -764,7 +764,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/10/date-puzzle-for-starters/index.html
+++ b/docs/blog/2010/10/date-puzzle-for-starters/index.html
@@ -681,7 +681,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -743,7 +743,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -778,7 +778,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -807,7 +807,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/10/el-get-reaches-1.0/index.html
+++ b/docs/blog/2010/10/el-get-reaches-1.0/index.html
@@ -944,7 +944,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1041,7 +1041,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1070,7 +1070,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/10/extensions-writing-a-patch-for-postgresql/index.html
+++ b/docs/blog/2010/10/extensions-writing-a-patch-for-postgresql/index.html
@@ -733,7 +733,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -795,7 +795,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -830,7 +830,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -859,7 +859,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/10/introducing-extensions/index.html
+++ b/docs/blog/2010/10/introducing-extensions/index.html
@@ -889,7 +889,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -951,7 +951,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -986,7 +986,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1015,7 +1015,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/10/resuming-work-on-extensions-first-little-step/index.html
+++ b/docs/blog/2010/10/resuming-work-on-extensions-first-little-step/index.html
@@ -649,7 +649,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -711,7 +711,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -746,7 +746,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -775,7 +775,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/11/dynamic-triggers-in-plpgsql/index.html
+++ b/docs/blog/2010/11/dynamic-triggers-in-plpgsql/index.html
@@ -646,7 +646,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -708,7 +708,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -743,7 +743,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -772,7 +772,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/11/pg_basebackup/index.html
+++ b/docs/blog/2010/11/pg_basebackup/index.html
@@ -644,7 +644,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -706,7 +706,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -741,7 +741,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -770,7 +770,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2010/12/el-get-1.1-with-174-recipes/index.html
+++ b/docs/blog/2010/12/el-get-1.1-with-174-recipes/index.html
@@ -685,7 +685,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -747,7 +747,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -782,7 +782,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -811,7 +811,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/01/starting-afresh-with-el-get/index.html
+++ b/docs/blog/2011/01/starting-afresh-with-el-get/index.html
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -748,7 +748,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -783,7 +783,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -812,7 +812,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/02/back-from-fosdem/index.html
+++ b/docs/blog/2011/02/back-from-fosdem/index.html
@@ -603,7 +603,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -665,7 +665,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -700,7 +700,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -729,7 +729,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/02/desktop-mode-and-readahead/index.html
+++ b/docs/blog/2011/02/desktop-mode-and-readahead/index.html
@@ -666,7 +666,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -728,7 +728,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -763,7 +763,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -792,7 +792,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/02/going-to-fosdem/index.html
+++ b/docs/blog/2011/02/going-to-fosdem/index.html
@@ -610,7 +610,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -672,7 +672,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -707,7 +707,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -736,7 +736,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/03/extensions-in-9.1/index.html
+++ b/docs/blog/2011/03/extensions-in-9.1/index.html
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -759,7 +759,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -788,7 +788,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/03/towards-pg_staging-1.0/index.html
+++ b/docs/blog/2011/03/towards-pg_staging-1.0/index.html
@@ -705,7 +705,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -767,7 +767,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -802,7 +802,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -831,7 +831,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/04/emacs-and-postgresql-pl-line-numbering/index.html
+++ b/docs/blog/2011/04/emacs-and-postgresql-pl-line-numbering/index.html
@@ -595,7 +595,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -657,7 +657,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -692,7 +692,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -721,7 +721,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/04/emacs-kicker/index.html
+++ b/docs/blog/2011/04/emacs-kicker/index.html
@@ -665,7 +665,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -727,7 +727,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -762,7 +762,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -791,7 +791,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/04/some-notes-about-skytools3/index.html
+++ b/docs/blog/2011/04/some-notes-about-skytools3/index.html
@@ -646,7 +646,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -708,7 +708,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -743,7 +743,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -772,7 +772,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/back-from-ottawa-preparing-for-cambridge/index.html
+++ b/docs/blog/2011/05/back-from-ottawa-preparing-for-cambridge/index.html
@@ -618,7 +618,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -680,7 +680,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -715,7 +715,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -744,7 +744,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/el-get-2.1/index.html
+++ b/docs/blog/2011/05/el-get-2.1/index.html
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -709,7 +709,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -738,7 +738,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/el-get-2.2/index.html
+++ b/docs/blog/2011/05/el-get-2.2/index.html
@@ -587,7 +587,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -649,7 +649,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -684,7 +684,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -713,7 +713,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/extension-module_pathname-and-.sql.in/index.html
+++ b/docs/blog/2011/05/extension-module_pathname-and-.sql.in/index.html
@@ -663,7 +663,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -725,7 +725,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -760,7 +760,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -789,7 +789,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/mailq-modeline-display/index.html
+++ b/docs/blog/2011/05/mailq-modeline-display/index.html
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -759,7 +759,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -788,7 +788,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/preparing-for-pgcon/index.html
+++ b/docs/blog/2011/05/preparing-for-pgcon/index.html
@@ -631,7 +631,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -693,7 +693,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -728,7 +728,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -757,7 +757,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/05/tables-and-views-dependencies/index.html
+++ b/docs/blog/2011/05/tables-and-views-dependencies/index.html
@@ -644,7 +644,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -706,7 +706,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -741,7 +741,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -770,7 +770,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/06/dont-be-afraid-of-cl/index.html
+++ b/docs/blog/2011/06/dont-be-afraid-of-cl/index.html
@@ -593,7 +593,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -655,7 +655,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -690,7 +690,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -719,7 +719,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/06/multi-version-support-for-extensions/index.html
+++ b/docs/blog/2011/06/multi-version-support-for-extensions/index.html
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -758,7 +758,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -793,7 +793,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -822,7 +822,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/back-from-char11/index.html
+++ b/docs/blog/2011/07/back-from-char11/index.html
@@ -654,7 +654,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -716,7 +716,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -751,7 +751,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -780,7 +780,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/comment-utiliser-pgloader/index.html
+++ b/docs/blog/2011/07/comment-utiliser-pgloader/index.html
@@ -586,7 +586,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -648,7 +648,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -683,7 +683,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -712,7 +712,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/configurer-pgloader/index.html
+++ b/docs/blog/2011/07/configurer-pgloader/index.html
@@ -585,7 +585,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -647,7 +647,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -682,7 +682,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -711,7 +711,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/de-retour-de-char11/index.html
+++ b/docs/blog/2011/07/de-retour-de-char11/index.html
@@ -681,7 +681,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -743,7 +743,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -778,7 +778,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -807,7 +807,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/elisp-breadcrumbs/index.html
+++ b/docs/blog/2011/07/elisp-breadcrumbs/index.html
@@ -633,7 +633,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -695,7 +695,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -730,7 +730,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -759,7 +759,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/emacs-ansi-colors/index.html
+++ b/docs/blog/2011/07/emacs-ansi-colors/index.html
@@ -633,7 +633,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -695,7 +695,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -730,7 +730,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -759,7 +759,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/emacs-cheat-sheet/index.html
+++ b/docs/blog/2011/07/emacs-cheat-sheet/index.html
@@ -589,7 +589,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -651,7 +651,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -686,7 +686,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -715,7 +715,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/how-to-setup-pgloader/index.html
+++ b/docs/blog/2011/07/how-to-setup-pgloader/index.html
@@ -809,7 +809,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -871,7 +871,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -906,7 +906,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -935,7 +935,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/how-to-use-pgloader/index.html
+++ b/docs/blog/2011/07/how-to-use-pgloader/index.html
@@ -730,7 +730,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -792,7 +792,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -827,7 +827,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -856,7 +856,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/muse-setup-revised/index.html
+++ b/docs/blog/2011/07/muse-setup-revised/index.html
@@ -634,7 +634,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -731,7 +731,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -760,7 +760,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/next-month-partitions/index.html
+++ b/docs/blog/2011/07/next-month-partitions/index.html
@@ -639,7 +639,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -701,7 +701,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -736,7 +736,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -765,7 +765,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/prêt-pour-char11/index.html
+++ b/docs/blog/2011/07/prêt-pour-char11/index.html
@@ -655,7 +655,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -717,7 +717,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -752,7 +752,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -781,7 +781,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/skytools3-les-slides/index.html
+++ b/docs/blog/2011/07/skytools3-les-slides/index.html
@@ -597,7 +597,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -659,7 +659,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -694,7 +694,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -723,7 +723,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/07/skytools3-talk-slides/index.html
+++ b/docs/blog/2011/07/skytools3-talk-slides/index.html
@@ -595,7 +595,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -657,7 +657,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -692,7 +692,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -721,7 +721,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/champs-statiques--pgloader/index.html
+++ b/docs/blog/2011/08/champs-statiques--pgloader/index.html
@@ -579,7 +579,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -641,7 +641,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -676,7 +676,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -705,7 +705,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/el-get-list-packages/index.html
+++ b/docs/blog/2011/08/el-get-list-packages/index.html
@@ -643,7 +643,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -705,7 +705,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -740,7 +740,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -769,7 +769,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/emacs-startup/index.html
+++ b/docs/blog/2011/08/emacs-startup/index.html
@@ -632,7 +632,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -694,7 +694,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -729,7 +729,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -758,7 +758,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/parallel-pgloader/index.html
+++ b/docs/blog/2011/08/parallel-pgloader/index.html
@@ -721,7 +721,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -783,7 +783,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -818,7 +818,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -847,7 +847,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pg_restore--l--pg_staging/index.html
+++ b/docs/blog/2011/08/pg_restore--l--pg_staging/index.html
@@ -697,7 +697,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -759,7 +759,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -794,7 +794,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -823,7 +823,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pgfincore-in-debian/index.html
+++ b/docs/blog/2011/08/pgfincore-in-debian/index.html
@@ -782,7 +782,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -844,7 +844,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -879,7 +879,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -908,7 +908,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pgloader-constant-cols/index.html
+++ b/docs/blog/2011/08/pgloader-constant-cols/index.html
@@ -691,7 +691,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -753,7 +753,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -788,7 +788,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -817,7 +817,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pgloader-en-parallèle/index.html
+++ b/docs/blog/2011/08/pgloader-en-parallèle/index.html
@@ -601,7 +601,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -663,7 +663,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -698,7 +698,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -727,7 +727,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pgloader-reformating/index.html
+++ b/docs/blog/2011/08/pgloader-reformating/index.html
@@ -712,7 +712,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -774,7 +774,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -809,7 +809,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -838,7 +838,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/pgloader-tutorial/index.html
+++ b/docs/blog/2011/08/pgloader-tutorial/index.html
@@ -578,7 +578,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -640,7 +640,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -675,7 +675,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -704,7 +704,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/reformater-avec-pgloader/index.html
+++ b/docs/blog/2011/08/reformater-avec-pgloader/index.html
@@ -583,7 +583,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -645,7 +645,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -680,7 +680,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -709,7 +709,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/see-tsung-in-action/index.html
+++ b/docs/blog/2011/08/see-tsung-in-action/index.html
@@ -600,7 +600,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -697,7 +697,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -726,7 +726,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/skytools-version-3/index.html
+++ b/docs/blog/2011/08/skytools-version-3/index.html
@@ -636,7 +636,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -698,7 +698,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -733,7 +733,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -762,7 +762,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/tutoriel-pgloader/index.html
+++ b/docs/blog/2011/08/tutoriel-pgloader/index.html
@@ -579,7 +579,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -641,7 +641,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -676,7 +676,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -705,7 +705,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/08/échappement-de-chaînes/index.html
+++ b/docs/blog/2011/08/échappement-de-chaînes/index.html
@@ -671,7 +671,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -733,7 +733,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -768,7 +768,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -797,7 +797,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/el-get-3.1/index.html
+++ b/docs/blog/2011/09/el-get-3.1/index.html
@@ -668,7 +668,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -730,7 +730,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -765,7 +765,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -794,7 +794,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/postgresql-9.1/index.html
+++ b/docs/blog/2011/09/postgresql-9.1/index.html
@@ -592,7 +592,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -654,7 +654,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -689,7 +689,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -718,7 +718,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/postgresql-and-debian/index.html
+++ b/docs/blog/2011/09/postgresql-and-debian/index.html
@@ -623,7 +623,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -685,7 +685,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -720,7 +720,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -749,7 +749,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/postgresql-à-amsterdam/index.html
+++ b/docs/blog/2011/09/postgresql-à-amsterdam/index.html
@@ -669,7 +669,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -731,7 +731,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -766,7 +766,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -795,7 +795,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/skytools3-walmgr/index.html
+++ b/docs/blog/2011/09/skytools3-walmgr/index.html
@@ -768,7 +768,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -830,7 +830,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -865,7 +865,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -894,7 +894,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/09/éviter-les-injections-sql/index.html
+++ b/docs/blog/2011/09/éviter-les-injections-sql/index.html
@@ -636,7 +636,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -698,7 +698,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -733,7 +733,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -762,7 +762,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/back-from-amsterdam/index.html
+++ b/docs/blog/2011/10/back-from-amsterdam/index.html
@@ -626,7 +626,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -688,7 +688,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -723,7 +723,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -752,7 +752,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/extensions-applications/index.html
+++ b/docs/blog/2011/10/extensions-applications/index.html
@@ -607,7 +607,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -669,7 +669,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -704,7 +704,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -733,7 +733,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/extensions-en-simple-sql/index.html
+++ b/docs/blog/2011/10/extensions-en-simple-sql/index.html
@@ -635,7 +635,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -697,7 +697,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -732,7 +732,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -761,7 +761,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/implementing-backups/index.html
+++ b/docs/blog/2011/10/implementing-backups/index.html
@@ -664,7 +664,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -726,7 +726,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -761,7 +761,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -790,7 +790,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/scaling-stored-procedures/index.html
+++ b/docs/blog/2011/10/scaling-stored-procedures/index.html
@@ -649,7 +649,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -711,7 +711,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -746,7 +746,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -775,7 +775,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/10/see-you-in-amsterdam/index.html
+++ b/docs/blog/2011/10/see-you-in-amsterdam/index.html
@@ -606,7 +606,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -668,7 +668,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -703,7 +703,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -732,7 +732,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2011/11/pgbouncer-munin-plugin/index.html
+++ b/docs/blog/2011/11/pgbouncer-munin-plugin/index.html
@@ -604,7 +604,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -666,7 +666,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -701,7 +701,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -730,7 +730,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/03/battle-language-à-la-marmite/index.html
+++ b/docs/blog/2012/03/battle-language-à-la-marmite/index.html
@@ -613,7 +613,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -675,7 +675,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -710,7 +710,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -739,7 +739,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/03/extension-white-listing/index.html
+++ b/docs/blog/2012/03/extension-white-listing/index.html
@@ -657,7 +657,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -719,7 +719,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -754,7 +754,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -783,7 +783,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/03/pgq-coop-consumers/index.html
+++ b/docs/blog/2012/03/pgq-coop-consumers/index.html
@@ -670,7 +670,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -732,7 +732,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -767,7 +767,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -796,7 +796,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/04/clean-pgq-subconsumers/index.html
+++ b/docs/blog/2012/04/clean-pgq-subconsumers/index.html
@@ -638,7 +638,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -700,7 +700,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -735,7 +735,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -764,7 +764,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/05/back-from-pgcon/index.html
+++ b/docs/blog/2012/05/back-from-pgcon/index.html
@@ -624,7 +624,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -721,7 +721,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -750,7 +750,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/06/m-x-recompile/index.html
+++ b/docs/blog/2012/06/m-x-recompile/index.html
@@ -644,7 +644,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -706,7 +706,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -741,7 +741,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -770,7 +770,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/06/pgday-france-2012/index.html
+++ b/docs/blog/2012/06/pgday-france-2012/index.html
@@ -596,7 +596,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -658,7 +658,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -693,7 +693,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -722,7 +722,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/07/solving-every-sudoku-puzzle/index.html
+++ b/docs/blog/2012/07/solving-every-sudoku-puzzle/index.html
@@ -888,7 +888,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -950,7 +950,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -985,7 +985,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1014,7 +1014,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/08/autumn-2012-conferences/index.html
+++ b/docs/blog/2012/08/autumn-2012-conferences/index.html
@@ -600,7 +600,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -697,7 +697,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -726,7 +726,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/08/el-get-4.1-is-out/index.html
+++ b/docs/blog/2012/08/el-get-4.1-is-out/index.html
@@ -869,7 +869,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -931,7 +931,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -966,7 +966,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -995,7 +995,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/08/fast-and-stupid/index.html
+++ b/docs/blog/2012/08/fast-and-stupid/index.html
@@ -778,7 +778,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -840,7 +840,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -875,7 +875,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -904,7 +904,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/09/postgresql-9.3/index.html
+++ b/docs/blog/2012/09/postgresql-9.3/index.html
@@ -835,7 +835,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -897,7 +897,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -932,7 +932,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -961,7 +961,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/10/another-awesome-conf/index.html
+++ b/docs/blog/2012/10/another-awesome-conf/index.html
@@ -624,7 +624,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -721,7 +721,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -750,7 +750,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/10/prefixes-and-ranges/index.html
+++ b/docs/blog/2012/10/prefixes-and-ranges/index.html
@@ -646,7 +646,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -708,7 +708,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -743,7 +743,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -772,7 +772,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/10/reset-counter/index.html
+++ b/docs/blog/2012/10/reset-counter/index.html
@@ -1067,7 +1067,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1129,7 +1129,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1164,7 +1164,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1193,7 +1193,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/about-vimgolf/index.html
+++ b/docs/blog/2012/11/about-vimgolf/index.html
@@ -903,7 +903,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -965,7 +965,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1000,7 +1000,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1029,7 +1029,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/cl-happy-numbers/index.html
+++ b/docs/blog/2012/11/cl-happy-numbers/index.html
@@ -697,7 +697,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -759,7 +759,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -794,7 +794,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -823,7 +823,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/concurrent-hello/index.html
+++ b/docs/blog/2012/11/concurrent-hello/index.html
@@ -675,7 +675,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -737,7 +737,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -772,7 +772,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -801,7 +801,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/editing-sql/index.html
+++ b/docs/blog/2012/11/editing-sql/index.html
@@ -726,7 +726,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -788,7 +788,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -823,7 +823,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -852,7 +852,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/m-x-ack/index.html
+++ b/docs/blog/2012/11/m-x-ack/index.html
@@ -624,7 +624,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -686,7 +686,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -721,7 +721,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -750,7 +750,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/11/postgresql-for-developers/index.html
+++ b/docs/blog/2012/11/postgresql-for-developers/index.html
@@ -606,7 +606,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -668,7 +668,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -703,7 +703,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -732,7 +732,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2012/12/inline-extensions/index.html
+++ b/docs/blog/2012/12/inline-extensions/index.html
@@ -1029,7 +1029,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1091,7 +1091,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1126,7 +1126,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1155,7 +1155,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/a-sunday-at-fosdem/index.html
+++ b/docs/blog/2013/01/a-sunday-at-fosdem/index.html
@@ -605,7 +605,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -667,7 +667,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -702,7 +702,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -731,7 +731,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/automated-setup-for-pgloader/index.html
+++ b/docs/blog/2013/01/automated-setup-for-pgloader/index.html
@@ -863,7 +863,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -925,7 +925,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -960,7 +960,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -989,7 +989,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/extensions-templates/index.html
+++ b/docs/blog/2013/01/extensions-templates/index.html
@@ -972,7 +972,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1034,7 +1034,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1069,7 +1069,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1098,7 +1098,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/fosdem-2013/index.html
+++ b/docs/blog/2013/01/fosdem-2013/index.html
@@ -656,7 +656,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -718,7 +718,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -753,7 +753,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -782,7 +782,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/lost-in-scope/index.html
+++ b/docs/blog/2013/01/lost-in-scope/index.html
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -786,7 +786,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -821,7 +821,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -850,7 +850,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/01/pgloader-whats-next/index.html
+++ b/docs/blog/2013/01/pgloader-whats-next/index.html
@@ -708,7 +708,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -770,7 +770,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -805,7 +805,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -834,7 +834,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/another-great-fosdem/index.html
+++ b/docs/blog/2013/02/another-great-fosdem/index.html
@@ -728,7 +728,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -790,7 +790,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -825,7 +825,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -854,7 +854,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/hyperloglog-unions/index.html
+++ b/docs/blog/2013/02/hyperloglog-unions/index.html
@@ -665,7 +665,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -727,7 +727,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -762,7 +762,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -791,7 +791,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/live-upgrading-pgq/index.html
+++ b/docs/blog/2013/02/live-upgrading-pgq/index.html
@@ -723,7 +723,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -785,7 +785,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -820,7 +820,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -849,7 +849,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/marking-whole-word/index.html
+++ b/docs/blog/2013/02/marking-whole-word/index.html
@@ -634,7 +634,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -731,7 +731,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -760,7 +760,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/playing-with-pgloader/index.html
+++ b/docs/blog/2013/02/playing-with-pgloader/index.html
@@ -857,7 +857,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -919,7 +919,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -954,7 +954,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -983,7 +983,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/02/postgresql-hyperloglog/index.html
+++ b/docs/blog/2013/02/postgresql-hyperloglog/index.html
@@ -828,7 +828,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -890,7 +890,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -925,7 +925,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -954,7 +954,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/03/batch-update/index.html
+++ b/docs/blog/2013/03/batch-update/index.html
@@ -833,7 +833,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -895,7 +895,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -930,7 +930,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -959,7 +959,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/03/bulk-replication/index.html
+++ b/docs/blog/2013/03/bulk-replication/index.html
@@ -692,7 +692,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -754,7 +754,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -789,7 +789,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -818,7 +818,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/03/emacs-conference/index.html
+++ b/docs/blog/2013/03/emacs-conference/index.html
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -709,7 +709,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -738,7 +738,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/03/the-need-for-speed/index.html
+++ b/docs/blog/2013/03/the-need-for-speed/index.html
@@ -596,7 +596,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -658,7 +658,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -693,7 +693,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -722,7 +722,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/04/emacs-conference/index.html
+++ b/docs/blog/2013/04/emacs-conference/index.html
@@ -647,7 +647,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -709,7 +709,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -744,7 +744,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -773,7 +773,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/05/from-parsing-to-compiling/index.html
+++ b/docs/blog/2013/05/from-parsing-to-compiling/index.html
@@ -746,7 +746,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -808,7 +808,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -843,7 +843,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -872,7 +872,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/05/nearest-big-city/index.html
+++ b/docs/blog/2013/05/nearest-big-city/index.html
@@ -878,7 +878,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -940,7 +940,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -975,7 +975,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1004,7 +1004,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/archiving-data-as-fast-as-possible/index.html
+++ b/docs/blog/2013/07/archiving-data-as-fast-as-possible/index.html
@@ -704,7 +704,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -766,7 +766,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -801,7 +801,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -830,7 +830,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/back-from-char13/index.html
+++ b/docs/blog/2013/07/back-from-char13/index.html
@@ -610,7 +610,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -672,7 +672,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -707,7 +707,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -736,7 +736,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/conferences-report/index.html
+++ b/docs/blog/2013/07/conferences-report/index.html
@@ -689,7 +689,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -751,7 +751,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -786,7 +786,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -815,7 +815,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/emacs-muse-meets-common-lisp/index.html
+++ b/docs/blog/2013/07/emacs-muse-meets-common-lisp/index.html
@@ -841,7 +841,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -903,7 +903,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -938,7 +938,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -967,7 +967,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/make-the-most-ouf-of-sql/index.html
+++ b/docs/blog/2013/07/make-the-most-ouf-of-sql/index.html
@@ -607,7 +607,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -669,7 +669,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -704,7 +704,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -733,7 +733,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/oscon-portland-and-pdxpug/index.html
+++ b/docs/blog/2013/07/oscon-portland-and-pdxpug/index.html
@@ -654,7 +654,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -716,7 +716,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -751,7 +751,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -780,7 +780,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/simple-case-for-pivoting-in-sql/index.html
+++ b/docs/blog/2013/07/simple-case-for-pivoting-in-sql/index.html
@@ -659,7 +659,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -721,7 +721,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -756,7 +756,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -785,7 +785,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/07/talking-at-the-sfpug/index.html
+++ b/docs/blog/2013/07/talking-at-the-sfpug/index.html
@@ -621,7 +621,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -683,7 +683,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -718,7 +718,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -747,7 +747,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/auditing-changes-with-hstore/index.html
+++ b/docs/blog/2013/08/auditing-changes-with-hstore/index.html
@@ -744,7 +744,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -806,7 +806,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -841,7 +841,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -870,7 +870,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/how-far-is-the-nearest-pub/index.html
+++ b/docs/blog/2013/08/how-far-is-the-nearest-pub/index.html
@@ -846,7 +846,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -908,7 +908,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -943,7 +943,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -972,7 +972,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/migrating-from-mysql-to-postgresql/index.html
+++ b/docs/blog/2013/08/migrating-from-mysql-to-postgresql/index.html
@@ -774,7 +774,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -836,7 +836,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -871,7 +871,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -900,7 +900,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/the-most-popular-pub-names/index.html
+++ b/docs/blog/2013/08/the-most-popular-pub-names/index.html
@@ -899,7 +899,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -961,7 +961,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -996,7 +996,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1025,7 +1025,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/trigger-parameters/index.html
+++ b/docs/blog/2013/08/trigger-parameters/index.html
@@ -790,7 +790,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -852,7 +852,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -887,7 +887,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -916,7 +916,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/08/understanding-window-functions/index.html
+++ b/docs/blog/2013/08/understanding-window-functions/index.html
@@ -1038,7 +1038,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1100,7 +1100,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1135,7 +1135,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1164,7 +1164,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/09/open-world-forum-2013/index.html
+++ b/docs/blog/2013/09/open-world-forum-2013/index.html
@@ -639,7 +639,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -701,7 +701,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -736,7 +736,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -765,7 +765,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/09/postgresql-data-recovery/index.html
+++ b/docs/blog/2013/09/postgresql-data-recovery/index.html
@@ -1493,7 +1493,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1555,7 +1555,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1590,7 +1590,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1619,7 +1619,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/09/using-trigrams-against-typos/index.html
+++ b/docs/blog/2013/09/using-trigrams-against-typos/index.html
@@ -884,7 +884,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -946,7 +946,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -981,7 +981,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1010,7 +1010,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/a-worthwile-micro-optimisation/index.html
+++ b/docs/blog/2013/10/a-worthwile-micro-optimisation/index.html
@@ -797,7 +797,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -859,7 +859,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -894,7 +894,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -923,7 +923,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/an-interview-about-mariadb-and-postgresql/index.html
+++ b/docs/blog/2013/10/an-interview-about-mariadb-and-postgresql/index.html
@@ -599,7 +599,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -661,7 +661,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -696,7 +696,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -725,7 +725,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/denormalizing-tags/index.html
+++ b/docs/blog/2013/10/denormalizing-tags/index.html
@@ -864,7 +864,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -926,7 +926,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -961,7 +961,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -990,7 +990,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/geolocation-with-postgresql/index.html
+++ b/docs/blog/2013/10/geolocation-with-postgresql/index.html
@@ -988,7 +988,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1050,7 +1050,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1085,7 +1085,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1114,7 +1114,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/loading-geolocation-data/index.html
+++ b/docs/blog/2013/10/loading-geolocation-data/index.html
@@ -1138,7 +1138,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1200,7 +1200,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1235,7 +1235,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1264,7 +1264,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/open-world-forum-conference/index.html
+++ b/docs/blog/2013/10/open-world-forum-conference/index.html
@@ -603,7 +603,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -665,7 +665,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -700,7 +700,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -729,7 +729,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/10/postgresql-autonomous-transaction/index.html
+++ b/docs/blog/2013/10/postgresql-autonomous-transaction/index.html
@@ -960,7 +960,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1022,7 +1022,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1057,7 +1057,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1086,7 +1086,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/11/back-from-dublin/index.html
+++ b/docs/blog/2013/11/back-from-dublin/index.html
@@ -650,7 +650,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -712,7 +712,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -747,7 +747,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -776,7 +776,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/11/groupe-dutilisateurs-postgresql-à-paris/index.html
+++ b/docs/blog/2013/11/groupe-dutilisateurs-postgresql-à-paris/index.html
@@ -695,7 +695,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -757,7 +757,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -792,7 +792,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -821,7 +821,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/11/import-fixed-width-data-with-pgloader/index.html
+++ b/docs/blog/2013/11/import-fixed-width-data-with-pgloader/index.html
@@ -779,7 +779,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -841,7 +841,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -876,7 +876,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -905,7 +905,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2013/11/migrating-sakila-from-mysql-to-postgresql/index.html
+++ b/docs/blog/2013/11/migrating-sakila-from-mysql-to-postgresql/index.html
@@ -727,7 +727,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -789,7 +789,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -824,7 +824,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -853,7 +853,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/01/el-get-is-now-rolling-releases/index.html
+++ b/docs/blog/2014/01/el-get-is-now-rolling-releases/index.html
@@ -614,7 +614,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -676,7 +676,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -711,7 +711,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -740,7 +740,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/01/fosdem-2014/index.html
+++ b/docs/blog/2014/01/fosdem-2014/index.html
@@ -589,7 +589,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -651,7 +651,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -686,7 +686,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -715,7 +715,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/01/postgresql-user-group-paris/index.html
+++ b/docs/blog/2014/01/postgresql-user-group-paris/index.html
@@ -660,7 +660,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -722,7 +722,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -757,7 +757,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -786,7 +786,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/02/aggregating-nba-data-postgresql-vs-mongodb/index.html
+++ b/docs/blog/2014/02/aggregating-nba-data-postgresql-vs-mongodb/index.html
@@ -989,7 +989,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1051,7 +1051,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1086,7 +1086,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1115,7 +1115,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/02/postgresql-aggregates-and-histograms/index.html
+++ b/docs/blog/2014/02/postgresql-aggregates-and-histograms/index.html
@@ -750,7 +750,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -812,7 +812,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -847,7 +847,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -876,7 +876,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/02/postgresql-fosdem-conference/index.html
+++ b/docs/blog/2014/02/postgresql-fosdem-conference/index.html
@@ -599,7 +599,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -661,7 +661,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -696,7 +696,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -725,7 +725,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/03/nordic-postgresql-day-2014/index.html
+++ b/docs/blog/2014/03/nordic-postgresql-day-2014/index.html
@@ -639,7 +639,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -701,7 +701,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -736,7 +736,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -765,7 +765,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/04/meetup-postgresql-à-paris/index.html
+++ b/docs/blog/2014/04/meetup-postgresql-à-paris/index.html
@@ -670,7 +670,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -732,7 +732,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -767,7 +767,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -796,7 +796,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/04/new-york/index.html
+++ b/docs/blog/2014/04/new-york/index.html
@@ -606,7 +606,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -668,7 +668,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -703,7 +703,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -732,7 +732,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/05/why-is-pgloader-so-much-faster/index.html
+++ b/docs/blog/2014/05/why-is-pgloader-so-much-faster/index.html
@@ -766,7 +766,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -828,7 +828,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -863,7 +863,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -892,7 +892,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/06/conférences-françaises/index.html
+++ b/docs/blog/2014/06/conférences-françaises/index.html
@@ -622,7 +622,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -684,7 +684,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -719,7 +719,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -748,7 +748,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/06/php-tour-2014/index.html
+++ b/docs/blog/2014/06/php-tour-2014/index.html
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -671,7 +671,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -706,7 +706,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -735,7 +735,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/08/going-to-chicago-postgres-open/index.html
+++ b/docs/blog/2014/08/going-to-chicago-postgres-open/index.html
@@ -653,7 +653,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -715,7 +715,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -750,7 +750,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -779,7 +779,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/08/turn-your-postgresql-queries-into-charts/index.html
+++ b/docs/blog/2014/08/turn-your-postgresql-queries-into-charts/index.html
@@ -656,7 +656,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -718,7 +718,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -753,7 +753,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -782,7 +782,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/09/php-tour-la-video/index.html
+++ b/docs/blog/2014/09/php-tour-la-video/index.html
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -709,7 +709,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -738,7 +738,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2014/10/meetup-postgresql-à-paris/index.html
+++ b/docs/blog/2014/10/meetup-postgresql-à-paris/index.html
@@ -625,7 +625,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -687,7 +687,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -722,7 +722,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -751,7 +751,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/01/my-first-slashdot-effect/index.html
+++ b/docs/blog/2015/01/my-first-slashdot-effect/index.html
@@ -631,7 +631,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -693,7 +693,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -728,7 +728,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -757,7 +757,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/01/new-release-pgloader-3.2/index.html
+++ b/docs/blog/2015/01/new-release-pgloader-3.2/index.html
@@ -709,7 +709,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -771,7 +771,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -806,7 +806,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -835,7 +835,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/02/back-from-fosdem-2015/index.html
+++ b/docs/blog/2015/02/back-from-fosdem-2015/index.html
@@ -651,7 +651,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -713,7 +713,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -748,7 +748,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -777,7 +777,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/03/a-pgday-in-paris/index.html
+++ b/docs/blog/2015/03/a-pgday-in-paris/index.html
@@ -628,7 +628,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -690,7 +690,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -725,7 +725,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -754,7 +754,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/04/pgday-paris/index.html
+++ b/docs/blog/2015/04/pgday-paris/index.html
@@ -705,7 +705,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -767,7 +767,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -802,7 +802,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -831,7 +831,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/05/postgresql-au-jug-de-montpellier/index.html
+++ b/docs/blog/2015/05/postgresql-au-jug-de-montpellier/index.html
@@ -662,7 +662,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -759,7 +759,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -788,7 +788,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/05/quicklisp-and-debian/index.html
+++ b/docs/blog/2015/05/quicklisp-and-debian/index.html
@@ -1014,7 +1014,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1076,7 +1076,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1111,7 +1111,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1140,7 +1140,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2015/11/all-your-base-conference-2015/index.html
+++ b/docs/blog/2015/11/all-your-base-conference-2015/index.html
@@ -634,7 +634,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -731,7 +731,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -760,7 +760,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2016/04/pgconf-us-2016/index.html
+++ b/docs/blog/2016/04/pgconf-us-2016/index.html
@@ -629,7 +629,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -691,7 +691,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -726,7 +726,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -755,7 +755,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/05/find-the-missing-integer/index.html
+++ b/docs/blog/2017/05/find-the-missing-integer/index.html
@@ -933,7 +933,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1030,7 +1030,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1059,7 +1059,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/06/exploring-a-data-set-in-sql/index.html
+++ b/docs/blog/2017/06/exploring-a-data-set-in-sql/index.html
@@ -1203,7 +1203,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1265,7 +1265,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1300,7 +1300,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1329,7 +1329,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/06/how-to-write-sql/index.html
+++ b/docs/blog/2017/06/how-to-write-sql/index.html
@@ -856,7 +856,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -918,7 +918,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -953,7 +953,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -982,7 +982,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/06/postgresql-and-the-calendar/index.html
+++ b/docs/blog/2017/06/postgresql-and-the-calendar/index.html
@@ -740,7 +740,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -802,7 +802,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -837,7 +837,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -866,7 +866,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/06/sql-and-business-logic/index.html
+++ b/docs/blog/2017/06/sql-and-business-logic/index.html
@@ -881,7 +881,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -943,7 +943,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -978,7 +978,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1007,7 +1007,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/07/from-mysql-to-postgresql/index.html
+++ b/docs/blog/2017/07/from-mysql-to-postgresql/index.html
@@ -999,7 +999,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1061,7 +1061,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1096,7 +1096,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1125,7 +1125,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/07/playing-with-unicode/index.html
+++ b/docs/blog/2017/07/playing-with-unicode/index.html
@@ -894,7 +894,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -956,7 +956,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -991,7 +991,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1020,7 +1020,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/08/regular-expressions-and-grouping-sets/index.html
+++ b/docs/blog/2017/08/regular-expressions-and-grouping-sets/index.html
@@ -842,7 +842,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -904,7 +904,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -939,7 +939,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -968,7 +968,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/08/sql-regression-tests/index.html
+++ b/docs/blog/2017/08/sql-regression-tests/index.html
@@ -794,7 +794,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -856,7 +856,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -891,7 +891,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -920,7 +920,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/09/mastering-postgresql-in-application-development/index.html
+++ b/docs/blog/2017/09/mastering-postgresql-in-application-development/index.html
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -709,7 +709,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -738,7 +738,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/09/on-json-and-sql/index.html
+++ b/docs/blog/2017/09/on-json-and-sql/index.html
@@ -1935,7 +1935,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1997,7 +1997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -2032,7 +2032,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -2061,7 +2061,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/10/set-returning-functions-and-postgresql-10/index.html
+++ b/docs/blog/2017/10/set-returning-functions-and-postgresql-10/index.html
@@ -774,7 +774,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -836,7 +836,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -871,7 +871,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -900,7 +900,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/11/mastering-postgresql-in-application-development-launches/index.html
+++ b/docs/blog/2017/11/mastering-postgresql-in-application-development-launches/index.html
@@ -784,7 +784,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -846,7 +846,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -881,7 +881,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -910,7 +910,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/11/simple-data-modeling-with-a-test-data-set/index.html
+++ b/docs/blog/2017/11/simple-data-modeling-with-a-test-data-set/index.html
@@ -1134,7 +1134,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1196,7 +1196,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1231,7 +1231,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1260,7 +1260,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/11/the-mode-ordered-set-aggregate-function/index.html
+++ b/docs/blog/2017/11/the-mode-ordered-set-aggregate-function/index.html
@@ -728,7 +728,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -790,7 +790,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -825,7 +825,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -854,7 +854,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/11/whats-in-a-name-mastering/index.html
+++ b/docs/blog/2017/11/whats-in-a-name-mastering/index.html
@@ -690,7 +690,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -752,7 +752,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -787,7 +787,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -816,7 +816,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/mastering-postgresql-a-readers-interview/index.html
+++ b/docs/blog/2017/12/mastering-postgresql-a-readers-interview/index.html
@@ -836,7 +836,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -898,7 +898,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -933,7 +933,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -962,7 +962,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/mastering-postgresql-more-about-the-docker-image/index.html
+++ b/docs/blog/2017/12/mastering-postgresql-more-about-the-docker-image/index.html
@@ -750,7 +750,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -812,7 +812,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -847,7 +847,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -876,7 +876,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/queen-princesses-and-workers/index.html
+++ b/docs/blog/2017/12/queen-princesses-and-workers/index.html
@@ -824,7 +824,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -886,7 +886,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -921,7 +921,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -950,7 +950,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/scaling-python-released/index.html
+++ b/docs/blog/2017/12/scaling-python-released/index.html
@@ -785,7 +785,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -847,7 +847,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -882,7 +882,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -911,7 +911,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/setting-up-psql-the-postgresql-cli/index.html
+++ b/docs/blog/2017/12/setting-up-psql-the-postgresql-cli/index.html
@@ -934,7 +934,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -996,7 +996,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1031,7 +1031,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1060,7 +1060,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2017/12/submit-a-talk-to-pgday-paris-today/index.html
+++ b/docs/blog/2017/12/submit-a-talk-to-pgday-paris-today/index.html
@@ -676,7 +676,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -738,7 +738,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -773,7 +773,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -802,7 +802,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/01/a-year-in-review-most-read-articles-in-2017/index.html
+++ b/docs/blog/2018/01/a-year-in-review-most-read-articles-in-2017/index.html
@@ -852,7 +852,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -914,7 +914,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -949,7 +949,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -978,7 +978,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/01/exporting-a-hierarchy-in-json-with-recursive-queries/index.html
+++ b/docs/blog/2018/01/exporting-a-hierarchy-in-json-with-recursive-queries/index.html
@@ -1031,7 +1031,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1093,7 +1093,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1128,7 +1128,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1157,7 +1157,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/01/migrating-to-postgresql-the-white-paper/index.html
+++ b/docs/blog/2018/01/migrating-to-postgresql-the-white-paper/index.html
@@ -696,7 +696,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -758,7 +758,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -793,7 +793,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -822,7 +822,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/01/working-at-citus-data/index.html
+++ b/docs/blog/2018/01/working-at-citus-data/index.html
@@ -700,7 +700,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -762,7 +762,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -797,7 +797,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -826,7 +826,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/02/find-the-number-of-the-longest-continuously-rising-days-for-a-stock/index.html
+++ b/docs/blog/2018/02/find-the-number-of-the-longest-continuously-rising-days-for-a-stock/index.html
@@ -1359,7 +1359,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1421,7 +1421,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1456,7 +1456,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1485,7 +1485,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/02/sustainable-open-source-development/index.html
+++ b/docs/blog/2018/02/sustainable-open-source-development/index.html
@@ -1065,7 +1065,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1127,7 +1127,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1162,7 +1162,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1191,7 +1191,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/03/database-modelization-anti-patterns/index.html
+++ b/docs/blog/2018/03/database-modelization-anti-patterns/index.html
@@ -930,7 +930,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1027,7 +1027,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1056,7 +1056,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/03/database-normalization-and-primary-keys/index.html
+++ b/docs/blog/2018/03/database-normalization-and-primary-keys/index.html
@@ -861,7 +861,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -923,7 +923,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -958,7 +958,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -987,7 +987,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/03/object-relational-database-management-system/index.html
+++ b/docs/blog/2018/03/object-relational-database-management-system/index.html
@@ -854,7 +854,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -916,7 +916,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -951,7 +951,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -980,7 +980,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-an-intro/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-an-intro/index.html
@@ -861,7 +861,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -923,7 +923,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -958,7 +958,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -987,7 +987,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-arrays/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-arrays/index.html
@@ -884,7 +884,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -946,7 +946,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -981,7 +981,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1010,7 +1010,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-date-and-time-processing/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-date-and-time-processing/index.html
@@ -855,7 +855,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -917,7 +917,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -952,7 +952,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -981,7 +981,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-json/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-json/index.html
@@ -757,7 +757,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -819,7 +819,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -854,7 +854,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -883,7 +883,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-network-addresses/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-network-addresses/index.html
@@ -751,7 +751,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -813,7 +813,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -848,7 +848,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -877,7 +877,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-ranges/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-ranges/index.html
@@ -781,7 +781,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -843,7 +843,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -878,7 +878,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -907,7 +907,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-text-encoding/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-text-encoding/index.html
@@ -745,7 +745,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -807,7 +807,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -842,7 +842,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -871,7 +871,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-text-processing/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-text-processing/index.html
@@ -861,7 +861,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -923,7 +923,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -958,7 +958,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -987,7 +987,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/04/postgresql-data-types-xml/index.html
+++ b/docs/blog/2018/04/postgresql-data-types-xml/index.html
@@ -689,7 +689,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -751,7 +751,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -786,7 +786,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -815,7 +815,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/05/postgresql-data-types-enum/index.html
+++ b/docs/blog/2018/05/postgresql-data-types-enum/index.html
@@ -739,7 +739,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -801,7 +801,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -836,7 +836,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -865,7 +865,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/05/postgresql-data-types-point/index.html
+++ b/docs/blog/2018/05/postgresql-data-types-point/index.html
@@ -1477,7 +1477,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1539,7 +1539,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1574,7 +1574,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1603,7 +1603,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/05/postgresql-data-types/index.html
+++ b/docs/blog/2018/05/postgresql-data-types/index.html
@@ -1066,7 +1066,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1128,7 +1128,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1163,7 +1163,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1192,7 +1192,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/06/postgresql-concurrency-data-modification-language/index.html
+++ b/docs/blog/2018/06/postgresql-concurrency-data-modification-language/index.html
@@ -1160,7 +1160,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1222,7 +1222,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1257,7 +1257,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1286,7 +1286,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/07/computing-and-caching/index.html
+++ b/docs/blog/2018/07/computing-and-caching/index.html
@@ -375,7 +375,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -880,7 +880,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -942,7 +942,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -977,7 +977,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1006,7 +1006,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/07/modeling-for-concurrency/index.html
+++ b/docs/blog/2018/07/modeling-for-concurrency/index.html
@@ -348,7 +348,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -869,7 +869,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -931,7 +931,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -966,7 +966,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -995,7 +995,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/07/postgresql-concurrency-isolation-and-locking/index.html
+++ b/docs/blog/2018/07/postgresql-concurrency-isolation-and-locking/index.html
@@ -332,7 +332,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
 
 <p>
@@ -490,7 +490,7 @@ progress to be included in PostgreSQL!</p>
 
 <div class="alert success ">
   <p>The application model for Tweeting is introduced in the first article of
-this series:<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+this series:<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
 </div>
 
@@ -856,7 +856,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -918,7 +918,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -953,7 +953,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -982,7 +982,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/blog/2018/07/postgresql-event-based-processing/index.html
+++ b/docs/blog/2018/07/postgresql-event-based-processing/index.html
@@ -443,7 +443,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1097,7 +1097,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1159,7 +1159,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1194,7 +1194,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1223,7 +1223,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -491,7 +491,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -553,7 +553,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -588,7 +588,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -617,7 +617,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/backups-and-recovery/index.html
+++ b/docs/categories/backups-and-recovery/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/book/index.html
+++ b/docs/categories/book/index.html
@@ -538,7 +538,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -600,7 +600,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -635,7 +635,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -664,7 +664,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/catalogs/index.html
+++ b/docs/categories/catalogs/index.html
@@ -677,7 +677,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -739,7 +739,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -774,7 +774,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -803,7 +803,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/citus/index.html
+++ b/docs/categories/citus/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/common-lisp/index.html
+++ b/docs/categories/common-lisp/index.html
@@ -936,7 +936,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1033,7 +1033,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1062,7 +1062,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/index.html
+++ b/docs/categories/conferences/index.html
@@ -1048,7 +1048,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1110,7 +1110,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1145,7 +1145,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1174,7 +1174,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/page/2/index.html
+++ b/docs/categories/conferences/page/2/index.html
@@ -1011,7 +1011,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1108,7 +1108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1137,7 +1137,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/page/3/index.html
+++ b/docs/categories/conferences/page/3/index.html
@@ -1014,7 +1014,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1076,7 +1076,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1111,7 +1111,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1140,7 +1140,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/page/4/index.html
+++ b/docs/categories/conferences/page/4/index.html
@@ -1008,7 +1008,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1070,7 +1070,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1105,7 +1105,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1134,7 +1134,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/page/5/index.html
+++ b/docs/categories/conferences/page/5/index.html
@@ -1002,7 +1002,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1064,7 +1064,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1099,7 +1099,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1128,7 +1128,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/conferences/page/6/index.html
+++ b/docs/categories/conferences/page/6/index.html
@@ -741,7 +741,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -803,7 +803,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -838,7 +838,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -867,7 +867,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/debian/index.html
+++ b/docs/categories/debian/index.html
@@ -898,7 +898,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -960,7 +960,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -995,7 +995,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1024,7 +1024,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/el-get/index.html
+++ b/docs/categories/el-get/index.html
@@ -914,7 +914,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -976,7 +976,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1011,7 +1011,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1040,7 +1040,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs-confs/index.html
+++ b/docs/categories/emacs-confs/index.html
@@ -531,7 +531,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -593,7 +593,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -628,7 +628,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -657,7 +657,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs-lisp/index.html
+++ b/docs/categories/emacs-lisp/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs-lisp/page/2/index.html
+++ b/docs/categories/emacs-lisp/page/2/index.html
@@ -614,7 +614,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -676,7 +676,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -711,7 +711,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -740,7 +740,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs-tips/index.html
+++ b/docs/categories/emacs-tips/index.html
@@ -999,7 +999,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1061,7 +1061,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1096,7 +1096,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1125,7 +1125,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs-tips/page/2/index.html
+++ b/docs/categories/emacs-tips/page/2/index.html
@@ -673,7 +673,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -735,7 +735,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -770,7 +770,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -799,7 +799,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs/index.html
+++ b/docs/categories/emacs/index.html
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1060,7 +1060,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1095,7 +1095,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1124,7 +1124,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs/page/2/index.html
+++ b/docs/categories/emacs/page/2/index.html
@@ -1003,7 +1003,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1065,7 +1065,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1100,7 +1100,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1129,7 +1129,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/emacs/page/3/index.html
+++ b/docs/categories/emacs/page/3/index.html
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -671,7 +671,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -706,7 +706,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -735,7 +735,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/encoding/index.html
+++ b/docs/categories/encoding/index.html
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -528,7 +528,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -563,7 +563,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -592,7 +592,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/extensions/index.html
+++ b/docs/categories/extensions/index.html
@@ -851,7 +851,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -913,7 +913,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -948,7 +948,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -977,7 +977,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/meetup/index.html
+++ b/docs/categories/meetup/index.html
@@ -531,7 +531,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -593,7 +593,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -628,7 +628,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -657,7 +657,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/pg_staging/index.html
+++ b/docs/categories/pg_staging/index.html
@@ -661,7 +661,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -723,7 +723,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -758,7 +758,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -787,7 +787,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/pgbouncer/index.html
+++ b/docs/categories/pgbouncer/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/pgloader/index.html
+++ b/docs/categories/pgloader/index.html
@@ -1074,7 +1074,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1136,7 +1136,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1171,7 +1171,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1200,7 +1200,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/pgloader/page/2/index.html
+++ b/docs/categories/pgloader/page/2/index.html
@@ -1040,7 +1040,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1102,7 +1102,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1137,7 +1137,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1166,7 +1166,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/pgloader/page/3/index.html
+++ b/docs/categories/pgloader/page/3/index.html
@@ -894,7 +894,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -956,7 +956,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -991,7 +991,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1020,7 +1020,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql-confs/index.html
+++ b/docs/categories/postgresql-confs/index.html
@@ -1039,7 +1039,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1101,7 +1101,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1136,7 +1136,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1165,7 +1165,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql-confs/page/2/index.html
+++ b/docs/categories/postgresql-confs/page/2/index.html
@@ -1014,7 +1014,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1076,7 +1076,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1111,7 +1111,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1140,7 +1140,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql-confs/page/3/index.html
+++ b/docs/categories/postgresql-confs/page/3/index.html
@@ -1007,7 +1007,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1069,7 +1069,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1104,7 +1104,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1133,7 +1133,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql-confs/page/4/index.html
+++ b/docs/categories/postgresql-confs/page/4/index.html
@@ -933,7 +933,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1030,7 +1030,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1059,7 +1059,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/index.html
+++ b/docs/categories/postgresql/index.html
@@ -312,7 +312,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -420,7 +420,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -576,7 +576,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1110,7 +1110,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1172,7 +1172,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1207,7 +1207,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1236,7 +1236,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/index.xml
+++ b/docs/categories/postgresql/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/categories/postgresql/page/10/index.html
+++ b/docs/categories/postgresql/page/10/index.html
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1103,7 +1103,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1132,7 +1132,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/11/index.html
+++ b/docs/categories/postgresql/page/11/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/12/index.html
+++ b/docs/categories/postgresql/page/12/index.html
@@ -937,7 +937,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -999,7 +999,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1034,7 +1034,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1063,7 +1063,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/2/index.html
+++ b/docs/categories/postgresql/page/2/index.html
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1145,7 +1145,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1180,7 +1180,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1209,7 +1209,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/3/index.html
+++ b/docs/categories/postgresql/page/3/index.html
@@ -1106,7 +1106,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1168,7 +1168,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1203,7 +1203,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1232,7 +1232,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/4/index.html
+++ b/docs/categories/postgresql/page/4/index.html
@@ -1075,7 +1075,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1137,7 +1137,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1172,7 +1172,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1201,7 +1201,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/5/index.html
+++ b/docs/categories/postgresql/page/5/index.html
@@ -1071,7 +1071,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1133,7 +1133,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1168,7 +1168,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1197,7 +1197,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/6/index.html
+++ b/docs/categories/postgresql/page/6/index.html
@@ -1101,7 +1101,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1163,7 +1163,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1198,7 +1198,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1227,7 +1227,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/7/index.html
+++ b/docs/categories/postgresql/page/7/index.html
@@ -1041,7 +1041,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1103,7 +1103,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1138,7 +1138,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1167,7 +1167,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/8/index.html
+++ b/docs/categories/postgresql/page/8/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresql/page/9/index.html
+++ b/docs/categories/postgresql/page/9/index.html
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1103,7 +1103,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1132,7 +1132,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresqlfr-confs/index.html
+++ b/docs/categories/postgresqlfr-confs/index.html
@@ -1024,7 +1024,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1086,7 +1086,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1121,7 +1121,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1150,7 +1150,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresqlfr-confs/page/2/index.html
+++ b/docs/categories/postgresqlfr-confs/page/2/index.html
@@ -419,7 +419,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -481,7 +481,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -516,7 +516,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -545,7 +545,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/postgresqlfr/index.html
+++ b/docs/categories/postgresqlfr/index.html
@@ -666,7 +666,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -728,7 +728,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -763,7 +763,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -792,7 +792,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/prefix/index.html
+++ b/docs/categories/prefix/index.html
@@ -783,7 +783,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -845,7 +845,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -880,7 +880,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -909,7 +909,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/preprepare/index.html
+++ b/docs/categories/preprepare/index.html
@@ -529,7 +529,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -591,7 +591,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -626,7 +626,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -655,7 +655,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/projects/index.html
+++ b/docs/categories/projects/index.html
@@ -1052,7 +1052,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1114,7 +1114,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1149,7 +1149,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1178,7 +1178,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/projects/page/2/index.html
+++ b/docs/categories/projects/page/2/index.html
@@ -1036,7 +1036,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1098,7 +1098,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1133,7 +1133,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1162,7 +1162,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/projects/page/3/index.html
+++ b/docs/categories/projects/page/3/index.html
@@ -1013,7 +1013,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1075,7 +1075,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1110,7 +1110,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1139,7 +1139,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/projects/page/4/index.html
+++ b/docs/categories/projects/page/4/index.html
@@ -1012,7 +1012,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1074,7 +1074,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1109,7 +1109,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1138,7 +1138,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/projects/page/5/index.html
+++ b/docs/categories/projects/page/5/index.html
@@ -802,7 +802,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -864,7 +864,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -899,7 +899,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -928,7 +928,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/python/index.html
+++ b/docs/categories/python/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/release/index.html
+++ b/docs/categories/release/index.html
@@ -528,7 +528,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -590,7 +590,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -625,7 +625,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -654,7 +654,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/skytools/index.html
+++ b/docs/categories/skytools/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/skytools/page/2/index.html
+++ b/docs/categories/skytools/page/2/index.html
@@ -418,7 +418,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -480,7 +480,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -515,7 +515,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -544,7 +544,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/software-programming/index.html
+++ b/docs/categories/software-programming/index.html
@@ -1019,7 +1019,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1081,7 +1081,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1116,7 +1116,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1145,7 +1145,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/software-programming/page/2/index.html
+++ b/docs/categories/software-programming/page/2/index.html
@@ -1002,7 +1002,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1064,7 +1064,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1099,7 +1099,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1128,7 +1128,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/software-programming/page/3/index.html
+++ b/docs/categories/software-programming/page/3/index.html
@@ -550,7 +550,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -647,7 +647,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -676,7 +676,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/switch-window/index.html
+++ b/docs/categories/switch-window/index.html
@@ -786,7 +786,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -848,7 +848,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -883,7 +883,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -912,7 +912,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/index.html
+++ b/docs/categories/yesql/index.html
@@ -312,7 +312,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -420,7 +420,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -576,7 +576,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1110,7 +1110,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1172,7 +1172,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1207,7 +1207,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1236,7 +1236,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/index.xml
+++ b/docs/categories/yesql/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/categories/yesql/page/2/index.html
+++ b/docs/categories/yesql/page/2/index.html
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1145,7 +1145,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1180,7 +1180,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1209,7 +1209,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/page/3/index.html
+++ b/docs/categories/yesql/page/3/index.html
@@ -1108,7 +1108,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1170,7 +1170,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1205,7 +1205,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1234,7 +1234,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/page/4/index.html
+++ b/docs/categories/yesql/page/4/index.html
@@ -1071,7 +1071,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1133,7 +1133,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1168,7 +1168,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1197,7 +1197,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/page/5/index.html
+++ b/docs/categories/yesql/page/5/index.html
@@ -1115,7 +1115,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1177,7 +1177,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1212,7 +1212,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1241,7 +1241,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/page/6/index.html
+++ b/docs/categories/yesql/page/6/index.html
@@ -1019,7 +1019,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1081,7 +1081,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1116,7 +1116,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1145,7 +1145,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/categories/yesql/page/7/index.html
+++ b/docs/categories/yesql/page/7/index.html
@@ -674,7 +674,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -736,7 +736,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -771,7 +771,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -800,7 +800,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/7th-european-lisp-symposium/index.html
+++ b/docs/conf/7th-european-lisp-symposium/index.html
@@ -545,7 +545,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -607,7 +607,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -642,7 +642,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -671,7 +671,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/all-your-base-conference-2015/index.html
+++ b/docs/conf/all-your-base-conference-2015/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/char-11/index.html
+++ b/docs/conf/char-11/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/char14/index.html
+++ b/docs/conf/char14/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/dalibo-session-#5/index.html
+++ b/docs/conf/dalibo-session-#5/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/el-get/index.html
+++ b/docs/conf/el-get/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/fosdem/index.html
+++ b/docs/conf/fosdem/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/index.html
+++ b/docs/conf/index.html
@@ -984,7 +984,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1046,7 +1046,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1081,7 +1081,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1110,7 +1110,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/nordic-pgday-2018/index.html
+++ b/docs/conf/nordic-pgday-2018/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/nordic-postgresql-day-2014/index.html
+++ b/docs/conf/nordic-postgresql-day-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/nordic-postgresql-day-2015/index.html
+++ b/docs/conf/nordic-postgresql-day-2015/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/open-world-forum-2013/index.html
+++ b/docs/conf/open-world-forum-2013/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/oscon/index.html
+++ b/docs/conf/oscon/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/page/2/index.html
+++ b/docs/conf/page/2/index.html
@@ -940,7 +940,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1002,7 +1002,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1037,7 +1037,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1066,7 +1066,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/page/3/index.html
+++ b/docs/conf/page/3/index.html
@@ -936,7 +936,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1033,7 +1033,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1062,7 +1062,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/page/4/index.html
+++ b/docs/conf/page/4/index.html
@@ -936,7 +936,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1033,7 +1033,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1062,7 +1062,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/pdxpug/index.html
+++ b/docs/conf/pdxpug/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/pgcon/index.html
+++ b/docs/conf/pgcon/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/pgconf-nyc-2014/index.html
+++ b/docs/conf/pgconf-nyc-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/pgday-fr-2014/index.html
+++ b/docs/conf/pgday-fr-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/pgday-france/index.html
+++ b/docs/conf/pgday-france/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/php-tour-lyon-2014/index.html
+++ b/docs/conf/php-tour-lyon-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgres-open-2012/index.html
+++ b/docs/conf/postgres-open-2012/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgres-open-2014-chicago/index.html
+++ b/docs/conf/postgres-open-2014-chicago/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-at-chtijug/index.html
+++ b/docs/conf/postgresql-at-chtijug/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-at-montpelliers-jug/index.html
+++ b/docs/conf/postgresql-at-montpelliers-jug/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-europe-2012/index.html
+++ b/docs/conf/postgresql-conference-europe-2012/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-europe-2013/index.html
+++ b/docs/conf/postgresql-conference-europe-2013/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-europe-2014/index.html
+++ b/docs/conf/postgresql-conference-europe-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-europe-2017/index.html
+++ b/docs/conf/postgresql-conference-europe-2017/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-europe/index.html
+++ b/docs/conf/postgresql-conference-europe/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-conference-us-2016/index.html
+++ b/docs/conf/postgresql-conference-us-2016/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-fosdem-2014/index.html
+++ b/docs/conf/postgresql-fosdem-2014/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/postgresql-fosdem-2015/index.html
+++ b/docs/conf/postgresql-fosdem-2015/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/présentation-de-postgresql/index.html
+++ b/docs/conf/présentation-de-postgresql/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/conf/sfpug-meeting/index.html
+++ b/docs/conf/sfpug-meeting/index.html
@@ -547,7 +547,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -609,7 +609,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -644,7 +644,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -673,7 +673,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -306,7 +306,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -414,7 +414,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -495,7 +495,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -570,7 +570,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1103,7 +1103,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1165,7 +1165,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1200,7 +1200,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1229,7 +1229,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/page/10/index.html
+++ b/docs/page/10/index.html
@@ -1029,7 +1029,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1091,7 +1091,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1126,7 +1126,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1155,7 +1155,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/11/index.html
+++ b/docs/page/11/index.html
@@ -1016,7 +1016,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1078,7 +1078,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1113,7 +1113,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1142,7 +1142,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/12/index.html
+++ b/docs/page/12/index.html
@@ -1010,7 +1010,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1072,7 +1072,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1107,7 +1107,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1136,7 +1136,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/13/index.html
+++ b/docs/page/13/index.html
@@ -1000,7 +1000,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1097,7 +1097,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1126,7 +1126,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/14/index.html
+++ b/docs/page/14/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/15/index.html
+++ b/docs/page/15/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/16/index.html
+++ b/docs/page/16/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/17/index.html
+++ b/docs/page/17/index.html
@@ -1026,7 +1026,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1088,7 +1088,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1123,7 +1123,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1152,7 +1152,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/18/index.html
+++ b/docs/page/18/index.html
@@ -1011,7 +1011,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1108,7 +1108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1137,7 +1137,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/19/index.html
+++ b/docs/page/19/index.html
@@ -994,7 +994,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1056,7 +1056,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1091,7 +1091,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1120,7 +1120,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/2/index.html
+++ b/docs/page/2/index.html
@@ -1076,7 +1076,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1138,7 +1138,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1173,7 +1173,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1202,7 +1202,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/20/index.html
+++ b/docs/page/20/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/21/index.html
+++ b/docs/page/21/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/22/index.html
+++ b/docs/page/22/index.html
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1092,7 +1092,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1121,7 +1121,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/23/index.html
+++ b/docs/page/23/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/24/index.html
+++ b/docs/page/24/index.html
@@ -994,7 +994,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1056,7 +1056,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1091,7 +1091,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1120,7 +1120,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/25/index.html
+++ b/docs/page/25/index.html
@@ -1000,7 +1000,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1097,7 +1097,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1126,7 +1126,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/26/index.html
+++ b/docs/page/26/index.html
@@ -996,7 +996,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1058,7 +1058,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1093,7 +1093,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1122,7 +1122,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/27/index.html
+++ b/docs/page/27/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/28/index.html
+++ b/docs/page/28/index.html
@@ -855,7 +855,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -917,7 +917,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -952,7 +952,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -981,7 +981,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/3/index.html
+++ b/docs/page/3/index.html
@@ -1099,7 +1099,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1161,7 +1161,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1196,7 +1196,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1225,7 +1225,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/4/index.html
+++ b/docs/page/4/index.html
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1130,7 +1130,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1165,7 +1165,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1194,7 +1194,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/5/index.html
+++ b/docs/page/5/index.html
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1130,7 +1130,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1165,7 +1165,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1194,7 +1194,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/6/index.html
+++ b/docs/page/6/index.html
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1119,7 +1119,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1154,7 +1154,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1183,7 +1183,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/7/index.html
+++ b/docs/page/7/index.html
@@ -1025,7 +1025,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1087,7 +1087,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1122,7 +1122,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1151,7 +1151,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/8/index.html
+++ b/docs/page/8/index.html
@@ -1021,7 +1021,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1118,7 +1118,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1147,7 +1147,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/9/index.html
+++ b/docs/page/9/index.html
@@ -1095,7 +1095,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1157,7 +1157,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1192,7 +1192,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1221,7 +1221,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -331,7 +331,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -393,7 +393,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -428,7 +428,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -457,7 +457,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/index.html
+++ b/docs/post/index.html
@@ -306,7 +306,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -414,7 +414,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -495,7 +495,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -570,7 +570,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1103,7 +1103,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1165,7 +1165,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1200,7 +1200,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1229,7 +1229,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/index.xml
+++ b/docs/post/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/post/page/10/index.html
+++ b/docs/post/page/10/index.html
@@ -1029,7 +1029,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1091,7 +1091,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1126,7 +1126,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1155,7 +1155,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/11/index.html
+++ b/docs/post/page/11/index.html
@@ -1016,7 +1016,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1078,7 +1078,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1113,7 +1113,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1142,7 +1142,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/12/index.html
+++ b/docs/post/page/12/index.html
@@ -1010,7 +1010,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1072,7 +1072,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1107,7 +1107,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1136,7 +1136,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/13/index.html
+++ b/docs/post/page/13/index.html
@@ -1000,7 +1000,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1097,7 +1097,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1126,7 +1126,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/14/index.html
+++ b/docs/post/page/14/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/15/index.html
+++ b/docs/post/page/15/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/16/index.html
+++ b/docs/post/page/16/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/17/index.html
+++ b/docs/post/page/17/index.html
@@ -1026,7 +1026,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1088,7 +1088,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1123,7 +1123,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1152,7 +1152,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/18/index.html
+++ b/docs/post/page/18/index.html
@@ -1011,7 +1011,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1108,7 +1108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1137,7 +1137,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/19/index.html
+++ b/docs/post/page/19/index.html
@@ -994,7 +994,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1056,7 +1056,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1091,7 +1091,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1120,7 +1120,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/2/index.html
+++ b/docs/post/page/2/index.html
@@ -1076,7 +1076,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1138,7 +1138,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1173,7 +1173,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1202,7 +1202,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/20/index.html
+++ b/docs/post/page/20/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/21/index.html
+++ b/docs/post/page/21/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/22/index.html
+++ b/docs/post/page/22/index.html
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1092,7 +1092,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1121,7 +1121,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/23/index.html
+++ b/docs/post/page/23/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/24/index.html
+++ b/docs/post/page/24/index.html
@@ -994,7 +994,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1056,7 +1056,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1091,7 +1091,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1120,7 +1120,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/25/index.html
+++ b/docs/post/page/25/index.html
@@ -1000,7 +1000,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1097,7 +1097,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1126,7 +1126,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/26/index.html
+++ b/docs/post/page/26/index.html
@@ -996,7 +996,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1058,7 +1058,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1093,7 +1093,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1122,7 +1122,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/27/index.html
+++ b/docs/post/page/27/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/28/index.html
+++ b/docs/post/page/28/index.html
@@ -855,7 +855,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -917,7 +917,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -952,7 +952,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -981,7 +981,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/3/index.html
+++ b/docs/post/page/3/index.html
@@ -1099,7 +1099,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1161,7 +1161,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1196,7 +1196,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1225,7 +1225,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/4/index.html
+++ b/docs/post/page/4/index.html
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1130,7 +1130,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1165,7 +1165,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1194,7 +1194,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/5/index.html
+++ b/docs/post/page/5/index.html
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1130,7 +1130,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1165,7 +1165,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1194,7 +1194,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/6/index.html
+++ b/docs/post/page/6/index.html
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1119,7 +1119,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1154,7 +1154,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1183,7 +1183,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/7/index.html
+++ b/docs/post/page/7/index.html
@@ -1025,7 +1025,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1087,7 +1087,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1122,7 +1122,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1151,7 +1151,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/8/index.html
+++ b/docs/post/page/8/index.html
@@ -1021,7 +1021,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1118,7 +1118,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1147,7 +1147,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/post/page/9/index.html
+++ b/docs/post/page/9/index.html
@@ -1095,7 +1095,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1157,7 +1157,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1192,7 +1192,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1221,7 +1221,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -663,7 +663,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -725,7 +725,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -760,7 +760,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -789,7 +789,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/9.1/index.html
+++ b/docs/tags/9.1/index.html
@@ -990,7 +990,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1052,7 +1052,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1087,7 +1087,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1116,7 +1116,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/9.1/page/2/index.html
+++ b/docs/tags/9.1/page/2/index.html
@@ -550,7 +550,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -612,7 +612,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -647,7 +647,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -676,7 +676,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/9.3/index.html
+++ b/docs/tags/9.3/index.html
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -525,7 +525,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -560,7 +560,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -589,7 +589,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/ack/index.html
+++ b/docs/tags/ack/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/anosql/index.html
+++ b/docs/tags/anosql/index.html
@@ -480,7 +480,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -542,7 +542,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -577,7 +577,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -606,7 +606,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/anti-join/index.html
+++ b/docs/tags/anti-join/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/anti-patterns/index.html
+++ b/docs/tags/anti-patterns/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/archiving/index.html
+++ b/docs/tags/archiving/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/arrays/index.html
+++ b/docs/tags/arrays/index.html
@@ -405,7 +405,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -467,7 +467,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -502,7 +502,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -531,7 +531,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/backports/index.html
+++ b/docs/tags/backports/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/backup/index.html
+++ b/docs/tags/backup/index.html
@@ -786,7 +786,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -848,7 +848,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -883,7 +883,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -912,7 +912,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/backups/index.html
+++ b/docs/tags/backups/index.html
@@ -464,7 +464,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -526,7 +526,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -561,7 +561,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -590,7 +590,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/book/index.html
+++ b/docs/tags/book/index.html
@@ -822,7 +822,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -884,7 +884,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -919,7 +919,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -948,7 +948,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/boolean/index.html
+++ b/docs/tags/boolean/index.html
@@ -414,7 +414,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -511,7 +511,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -540,7 +540,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/calendar/index.html
+++ b/docs/tags/calendar/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/catalogs/index.html
+++ b/docs/tags/catalogs/index.html
@@ -1031,7 +1031,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1093,7 +1093,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1128,7 +1128,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1157,7 +1157,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/catalogs/page/2/index.html
+++ b/docs/tags/catalogs/page/2/index.html
@@ -426,7 +426,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -488,7 +488,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -523,7 +523,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -552,7 +552,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/cidr/index.html
+++ b/docs/tags/cidr/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/citus/index.html
+++ b/docs/tags/citus/index.html
@@ -410,7 +410,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -472,7 +472,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -507,7 +507,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -536,7 +536,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/clos/index.html
+++ b/docs/tags/clos/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/common-lisp/index.html
+++ b/docs/tags/common-lisp/index.html
@@ -1047,7 +1047,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1109,7 +1109,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1144,7 +1144,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1173,7 +1173,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/common-lisp/page/2/index.html
+++ b/docs/tags/common-lisp/page/2/index.html
@@ -867,7 +867,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -929,7 +929,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -964,7 +964,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -993,7 +993,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/concurrency/index.html
+++ b/docs/tags/concurrency/index.html
@@ -310,7 +310,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -418,7 +418,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -499,7 +499,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -574,7 +574,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -738,7 +738,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -800,7 +800,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -835,7 +835,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -864,7 +864,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/concurrency/index.xml
+++ b/docs/tags/concurrency/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/tags/conferences/index.html
+++ b/docs/tags/conferences/index.html
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1119,7 +1119,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1154,7 +1154,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1183,7 +1183,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/conferences/page/2/index.html
+++ b/docs/tags/conferences/page/2/index.html
@@ -1010,7 +1010,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1072,7 +1072,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1107,7 +1107,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1136,7 +1136,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/conferences/page/3/index.html
+++ b/docs/tags/conferences/page/3/index.html
@@ -1011,7 +1011,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1108,7 +1108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1137,7 +1137,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/conferences/page/4/index.html
+++ b/docs/tags/conferences/page/4/index.html
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1103,7 +1103,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1132,7 +1132,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/conferences/page/5/index.html
+++ b/docs/tags/conferences/page/5/index.html
@@ -1000,7 +1000,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1097,7 +1097,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1126,7 +1126,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/conferences/page/6/index.html
+++ b/docs/tags/conferences/page/6/index.html
@@ -675,7 +675,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -737,7 +737,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -772,7 +772,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -801,7 +801,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/crud/index.html
+++ b/docs/tags/crud/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/cssh/index.html
+++ b/docs/tags/cssh/index.html
@@ -784,7 +784,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -846,7 +846,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -881,7 +881,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -910,7 +910,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/cube/index.html
+++ b/docs/tags/cube/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/data-types/index.html
+++ b/docs/tags/data-types/index.html
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1119,7 +1119,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1154,7 +1154,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1183,7 +1183,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/data-types/page/2/index.html
+++ b/docs/tags/data-types/page/2/index.html
@@ -504,7 +504,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -566,7 +566,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -601,7 +601,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -630,7 +630,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/data/index.html
+++ b/docs/tags/data/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/date-ranges/index.html
+++ b/docs/tags/date-ranges/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/date/index.html
+++ b/docs/tags/date/index.html
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -538,7 +538,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -573,7 +573,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -602,7 +602,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/debian/index.html
+++ b/docs/tags/debian/index.html
@@ -989,7 +989,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1051,7 +1051,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1086,7 +1086,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1115,7 +1115,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/debian/page/2/index.html
+++ b/docs/tags/debian/page/2/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/debian/page/3/index.html
+++ b/docs/tags/debian/page/3/index.html
@@ -416,7 +416,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -478,7 +478,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -513,7 +513,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -542,7 +542,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/delete/index.html
+++ b/docs/tags/delete/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/distributed/index.html
+++ b/docs/tags/distributed/index.html
@@ -410,7 +410,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -472,7 +472,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -507,7 +507,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -536,7 +536,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/dnd/index.html
+++ b/docs/tags/dnd/index.html
@@ -411,7 +411,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -473,7 +473,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -508,7 +508,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -537,7 +537,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/docker/index.html
+++ b/docs/tags/docker/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/earthdistance/index.html
+++ b/docs/tags/earthdistance/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/el-get/index.html
+++ b/docs/tags/el-get/index.html
@@ -993,7 +993,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1055,7 +1055,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1090,7 +1090,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1119,7 +1119,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/el-get/page/2/index.html
+++ b/docs/tags/el-get/page/2/index.html
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1092,7 +1092,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1121,7 +1121,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/el-get/page/3/index.html
+++ b/docs/tags/el-get/page/3/index.html
@@ -417,7 +417,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -479,7 +479,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -514,7 +514,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -543,7 +543,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/elt/index.html
+++ b/docs/tags/elt/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs-kicker/index.html
+++ b/docs/tags/emacs-kicker/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/index.html
+++ b/docs/tags/emacs/index.html
@@ -999,7 +999,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1061,7 +1061,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1096,7 +1096,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1125,7 +1125,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/page/2/index.html
+++ b/docs/tags/emacs/page/2/index.html
@@ -1002,7 +1002,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1064,7 +1064,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1099,7 +1099,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1128,7 +1128,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/page/3/index.html
+++ b/docs/tags/emacs/page/3/index.html
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1060,7 +1060,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1095,7 +1095,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1124,7 +1124,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/page/4/index.html
+++ b/docs/tags/emacs/page/4/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/page/5/index.html
+++ b/docs/tags/emacs/page/5/index.html
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1060,7 +1060,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1095,7 +1095,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1124,7 +1124,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/emacs/page/6/index.html
+++ b/docs/tags/emacs/page/6/index.html
@@ -544,7 +544,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -606,7 +606,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -641,7 +641,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -670,7 +670,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/encoding/index.html
+++ b/docs/tags/encoding/index.html
@@ -537,7 +537,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -599,7 +599,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -634,7 +634,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -663,7 +663,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/enum/index.html
+++ b/docs/tags/enum/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/etl/index.html
+++ b/docs/tags/etl/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/event-triggers/index.html
+++ b/docs/tags/event-triggers/index.html
@@ -403,7 +403,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -465,7 +465,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -500,7 +500,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -529,7 +529,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/except/index.html
+++ b/docs/tags/except/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/exploration/index.html
+++ b/docs/tags/exploration/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/extensions/index.html
+++ b/docs/tags/extensions/index.html
@@ -1058,7 +1058,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1120,7 +1120,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1155,7 +1155,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1184,7 +1184,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/extensions/page/2/index.html
+++ b/docs/tags/extensions/page/2/index.html
@@ -1024,7 +1024,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1086,7 +1086,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1121,7 +1121,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1150,7 +1150,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/extensions/page/3/index.html
+++ b/docs/tags/extensions/page/3/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/extensions/page/4/index.html
+++ b/docs/tags/extensions/page/4/index.html
@@ -737,7 +737,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -799,7 +799,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -834,7 +834,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -863,7 +863,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/flags/index.html
+++ b/docs/tags/flags/index.html
@@ -405,7 +405,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -467,7 +467,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -502,7 +502,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -531,7 +531,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/fosdem/index.html
+++ b/docs/tags/fosdem/index.html
@@ -859,7 +859,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -921,7 +921,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -956,7 +956,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -985,7 +985,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/fotolog/index.html
+++ b/docs/tags/fotolog/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/function-overloading/index.html
+++ b/docs/tags/function-overloading/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/funding/index.html
+++ b/docs/tags/funding/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/generate_series/index.html
+++ b/docs/tags/generate_series/index.html
@@ -479,7 +479,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -541,7 +541,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -576,7 +576,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -605,7 +605,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/geolocation/index.html
+++ b/docs/tags/geolocation/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/geometry/index.html
+++ b/docs/tags/geometry/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/grep/index.html
+++ b/docs/tags/grep/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/grouping-sets/index.html
+++ b/docs/tags/grouping-sets/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/high-availability/index.html
+++ b/docs/tags/high-availability/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/histogram/index.html
+++ b/docs/tags/histogram/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/histograms/index.html
+++ b/docs/tags/histograms/index.html
@@ -405,7 +405,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -467,7 +467,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -502,7 +502,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -531,7 +531,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/hstore/index.html
+++ b/docs/tags/hstore/index.html
@@ -482,7 +482,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -544,7 +544,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -579,7 +579,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -608,7 +608,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/inet/index.html
+++ b/docs/tags/inet/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/insert/index.html
+++ b/docs/tags/insert/index.html
@@ -308,7 +308,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -538,7 +538,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -573,7 +573,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -602,7 +602,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/insert/index.xml
+++ b/docs/tags/insert/index.xml
@@ -25,7 +25,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 

--- a/docs/tags/intagg/index.html
+++ b/docs/tags/intagg/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/interval/index.html
+++ b/docs/tags/interval/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/ip4r/index.html
+++ b/docs/tags/ip4r/index.html
@@ -744,7 +744,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -806,7 +806,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -841,7 +841,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -870,7 +870,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/isolation/index.html
+++ b/docs/tags/isolation/index.html
@@ -307,7 +307,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/isolation/index.xml
+++ b/docs/tags/isolation/index.xml
@@ -24,7 +24,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/tags/javascript/index.html
+++ b/docs/tags/javascript/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/json/index.html
+++ b/docs/tags/json/index.html
@@ -483,7 +483,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -545,7 +545,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -580,7 +580,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -609,7 +609,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/knn/index.html
+++ b/docs/tags/knn/index.html
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -533,7 +533,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -568,7 +568,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -597,7 +597,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/lateral/index.html
+++ b/docs/tags/lateral/index.html
@@ -413,7 +413,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -475,7 +475,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -510,7 +510,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -539,7 +539,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/lisp/index.html
+++ b/docs/tags/lisp/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/load-balancing/index.html
+++ b/docs/tags/load-balancing/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/locking/index.html
+++ b/docs/tags/locking/index.html
@@ -307,7 +307,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/locking/index.xml
+++ b/docs/tags/locking/index.xml
@@ -24,7 +24,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/tags/londiste/index.html
+++ b/docs/tags/londiste/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/lorem/index.html
+++ b/docs/tags/lorem/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/lparallel/index.html
+++ b/docs/tags/lparallel/index.html
@@ -464,7 +464,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -526,7 +526,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -561,7 +561,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -590,7 +590,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mailq/index.html
+++ b/docs/tags/mailq/index.html
@@ -591,7 +591,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -653,7 +653,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -688,7 +688,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -717,7 +717,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mariadb/index.html
+++ b/docs/tags/mariadb/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/master/index.html
+++ b/docs/tags/master/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mastering-postgresql/index.html
+++ b/docs/tags/mastering-postgresql/index.html
@@ -477,7 +477,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -539,7 +539,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -574,7 +574,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -603,7 +603,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mastering/index.html
+++ b/docs/tags/mastering/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/materialized-views/index.html
+++ b/docs/tags/materialized-views/index.html
@@ -311,7 +311,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -420,7 +420,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -482,7 +482,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -517,7 +517,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -546,7 +546,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/materialized-views/index.xml
+++ b/docs/tags/materialized-views/index.xml
@@ -28,7 +28,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s

--- a/docs/tags/median/index.html
+++ b/docs/tags/median/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/meetup/index.html
+++ b/docs/tags/meetup/index.html
@@ -598,7 +598,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -660,7 +660,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -695,7 +695,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -724,7 +724,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/migration/index.html
+++ b/docs/tags/migration/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mode/index.html
+++ b/docs/tags/mode/index.html
@@ -414,7 +414,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -511,7 +511,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -540,7 +540,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/model/index.html
+++ b/docs/tags/model/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/modeline/index.html
+++ b/docs/tags/modeline/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/modeling/index.html
+++ b/docs/tags/modeling/index.html
@@ -308,7 +308,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -413,7 +413,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -448,7 +448,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -477,7 +477,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/modeling/index.xml
+++ b/docs/tags/modeling/index.xml
@@ -25,7 +25,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 

--- a/docs/tags/modelisation/index.html
+++ b/docs/tags/modelisation/index.html
@@ -308,7 +308,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -558,7 +558,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -620,7 +620,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -655,7 +655,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -684,7 +684,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/modelisation/index.xml
+++ b/docs/tags/modelisation/index.xml
@@ -25,7 +25,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 

--- a/docs/tags/mongodb/index.html
+++ b/docs/tags/mongodb/index.html
@@ -543,7 +543,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -605,7 +605,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -640,7 +640,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -669,7 +669,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/monitoring/index.html
+++ b/docs/tags/monitoring/index.html
@@ -399,7 +399,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -461,7 +461,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -496,7 +496,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -525,7 +525,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/munin/index.html
+++ b/docs/tags/munin/index.html
@@ -399,7 +399,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -461,7 +461,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -496,7 +496,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -525,7 +525,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/muse/index.html
+++ b/docs/tags/muse/index.html
@@ -991,7 +991,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1053,7 +1053,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1088,7 +1088,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1117,7 +1117,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/muse/page/2/index.html
+++ b/docs/tags/muse/page/2/index.html
@@ -484,7 +484,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -546,7 +546,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -581,7 +581,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -610,7 +610,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/mysql/index.html
+++ b/docs/tags/mysql/index.html
@@ -553,7 +553,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -615,7 +615,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -650,7 +650,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -679,7 +679,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/network-address/index.html
+++ b/docs/tags/network-address/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/normal-forms/index.html
+++ b/docs/tags/normal-forms/index.html
@@ -410,7 +410,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -472,7 +472,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -507,7 +507,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -536,7 +536,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/normalization/index.html
+++ b/docs/tags/normalization/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/not-exists/index.html
+++ b/docs/tags/not-exists/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/object-oriented-programming/index.html
+++ b/docs/tags/object-oriented-programming/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/object-relational/index.html
+++ b/docs/tags/object-relational/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/open-source/index.html
+++ b/docs/tags/open-source/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/ordered-set-aggregates/index.html
+++ b/docs/tags/ordered-set-aggregates/index.html
@@ -414,7 +414,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -511,7 +511,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -540,7 +540,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/oscon/index.html
+++ b/docs/tags/oscon/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/percentile/index.html
+++ b/docs/tags/percentile/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pg_staging/index.html
+++ b/docs/tags/pg_staging/index.html
@@ -853,7 +853,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -915,7 +915,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -950,7 +950,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -979,7 +979,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pg_trgm/index.html
+++ b/docs/tags/pg_trgm/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgbouncer/index.html
+++ b/docs/tags/pgbouncer/index.html
@@ -399,7 +399,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -461,7 +461,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -496,7 +496,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -525,7 +525,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgcon/index.html
+++ b/docs/tags/pgcon/index.html
@@ -720,7 +720,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -782,7 +782,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -817,7 +817,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -846,7 +846,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgdevenv-el/index.html
+++ b/docs/tags/pgdevenv-el/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgextwlist/index.html
+++ b/docs/tags/pgextwlist/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgfincore/index.html
+++ b/docs/tags/pgfincore/index.html
@@ -398,7 +398,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -460,7 +460,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -495,7 +495,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -524,7 +524,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgfouine/index.html
+++ b/docs/tags/pgfouine/index.html
@@ -401,7 +401,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -463,7 +463,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -498,7 +498,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -527,7 +527,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgloader/index.html
+++ b/docs/tags/pgloader/index.html
@@ -1062,7 +1062,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1124,7 +1124,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1159,7 +1159,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1188,7 +1188,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgloader/page/2/index.html
+++ b/docs/tags/pgloader/page/2/index.html
@@ -1046,7 +1046,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1108,7 +1108,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1143,7 +1143,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1172,7 +1172,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgloader/page/3/index.html
+++ b/docs/tags/pgloader/page/3/index.html
@@ -1026,7 +1026,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1088,7 +1088,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1123,7 +1123,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1152,7 +1152,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgq/index.html
+++ b/docs/tags/pgq/index.html
@@ -590,7 +590,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -652,7 +652,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -687,7 +687,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -716,7 +716,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/pgsql-linum-format/index.html
+++ b/docs/tags/pgsql-linum-format/index.html
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -524,7 +524,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -559,7 +559,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -588,7 +588,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/plpgsql/index.html
+++ b/docs/tags/plpgsql/index.html
@@ -724,7 +724,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -786,7 +786,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -821,7 +821,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -850,7 +850,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/plproxy/index.html
+++ b/docs/tags/plproxy/index.html
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -536,7 +536,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -571,7 +571,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -600,7 +600,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/point/index.html
+++ b/docs/tags/point/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postfix/index.html
+++ b/docs/tags/postfix/index.html
@@ -527,7 +527,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -589,7 +589,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -624,7 +624,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -653,7 +653,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/index.html
+++ b/docs/tags/postgresql/index.html
@@ -310,7 +310,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -418,7 +418,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -499,7 +499,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -574,7 +574,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1108,7 +1108,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1170,7 +1170,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1205,7 +1205,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1234,7 +1234,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/index.xml
+++ b/docs/tags/postgresql/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/tags/postgresql/page/10/index.html
+++ b/docs/tags/postgresql/page/10/index.html
@@ -1021,7 +1021,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1118,7 +1118,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1147,7 +1147,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/11/index.html
+++ b/docs/tags/postgresql/page/11/index.html
@@ -1009,7 +1009,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1071,7 +1071,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1106,7 +1106,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1135,7 +1135,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/12/index.html
+++ b/docs/tags/postgresql/page/12/index.html
@@ -999,7 +999,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1061,7 +1061,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1096,7 +1096,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1125,7 +1125,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/13/index.html
+++ b/docs/tags/postgresql/page/13/index.html
@@ -1018,7 +1018,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1080,7 +1080,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1115,7 +1115,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1144,7 +1144,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/14/index.html
+++ b/docs/tags/postgresql/page/14/index.html
@@ -1021,7 +1021,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1083,7 +1083,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1118,7 +1118,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1147,7 +1147,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/15/index.html
+++ b/docs/tags/postgresql/page/15/index.html
@@ -997,7 +997,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1059,7 +1059,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1094,7 +1094,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1123,7 +1123,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/16/index.html
+++ b/docs/tags/postgresql/page/16/index.html
@@ -1005,7 +1005,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1067,7 +1067,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1102,7 +1102,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1131,7 +1131,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/17/index.html
+++ b/docs/tags/postgresql/page/17/index.html
@@ -995,7 +995,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1057,7 +1057,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1092,7 +1092,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1121,7 +1121,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/18/index.html
+++ b/docs/tags/postgresql/page/18/index.html
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1103,7 +1103,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1132,7 +1132,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/19/index.html
+++ b/docs/tags/postgresql/page/19/index.html
@@ -1003,7 +1003,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1065,7 +1065,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1100,7 +1100,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1129,7 +1129,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/2/index.html
+++ b/docs/tags/postgresql/page/2/index.html
@@ -1081,7 +1081,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1143,7 +1143,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1178,7 +1178,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1207,7 +1207,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/3/index.html
+++ b/docs/tags/postgresql/page/3/index.html
@@ -1104,7 +1104,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1166,7 +1166,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1201,7 +1201,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1230,7 +1230,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/4/index.html
+++ b/docs/tags/postgresql/page/4/index.html
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1135,7 +1135,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1170,7 +1170,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1199,7 +1199,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/5/index.html
+++ b/docs/tags/postgresql/page/5/index.html
@@ -1073,7 +1073,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1135,7 +1135,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1170,7 +1170,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1199,7 +1199,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/6/index.html
+++ b/docs/tags/postgresql/page/6/index.html
@@ -1045,7 +1045,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1107,7 +1107,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1142,7 +1142,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1171,7 +1171,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/7/index.html
+++ b/docs/tags/postgresql/page/7/index.html
@@ -1045,7 +1045,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1107,7 +1107,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1142,7 +1142,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1171,7 +1171,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/8/index.html
+++ b/docs/tags/postgresql/page/8/index.html
@@ -1097,7 +1097,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1159,7 +1159,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1194,7 +1194,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1223,7 +1223,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresql/page/9/index.html
+++ b/docs/tags/postgresql/page/9/index.html
@@ -1028,7 +1028,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1090,7 +1090,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1125,7 +1125,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1154,7 +1154,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresqlfr/index.html
+++ b/docs/tags/postgresqlfr/index.html
@@ -1026,7 +1026,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1088,7 +1088,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1123,7 +1123,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1152,7 +1152,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresqlfr/page/2/index.html
+++ b/docs/tags/postgresqlfr/page/2/index.html
@@ -1006,7 +1006,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1068,7 +1068,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1103,7 +1103,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1132,7 +1132,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/postgresqlfr/page/3/index.html
+++ b/docs/tags/postgresqlfr/page/3/index.html
@@ -867,7 +867,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -929,7 +929,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -964,7 +964,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -993,7 +993,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/prefix/index.html
+++ b/docs/tags/prefix/index.html
@@ -996,7 +996,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1058,7 +1058,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1093,7 +1093,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1122,7 +1122,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/prefix/page/2/index.html
+++ b/docs/tags/prefix/page/2/index.html
@@ -608,7 +608,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -670,7 +670,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -705,7 +705,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -734,7 +734,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/preprepare/index.html
+++ b/docs/tags/preprepare/index.html
@@ -527,7 +527,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -589,7 +589,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -624,7 +624,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -653,7 +653,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/primary-keys/index.html
+++ b/docs/tags/primary-keys/index.html
@@ -410,7 +410,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -472,7 +472,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -507,7 +507,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -536,7 +536,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/psql/index.html
+++ b/docs/tags/psql/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/puzzle/index.html
+++ b/docs/tags/puzzle/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/python/index.html
+++ b/docs/tags/python/index.html
@@ -743,7 +743,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -805,7 +805,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -840,7 +840,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -869,7 +869,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/random/index.html
+++ b/docs/tags/random/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/ranges/index.html
+++ b/docs/tags/ranges/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/rcirc/index.html
+++ b/docs/tags/rcirc/index.html
@@ -593,7 +593,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -655,7 +655,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -690,7 +690,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -719,7 +719,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/recovery/index.html
+++ b/docs/tags/recovery/index.html
@@ -399,7 +399,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -461,7 +461,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -496,7 +496,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -525,7 +525,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/recursive/index.html
+++ b/docs/tags/recursive/index.html
@@ -497,7 +497,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -559,7 +559,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -594,7 +594,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -623,7 +623,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/regex/index.html
+++ b/docs/tags/regex/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/regression/index.html
+++ b/docs/tags/regression/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/release/index.html
+++ b/docs/tags/release/index.html
@@ -987,7 +987,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1049,7 +1049,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1084,7 +1084,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1113,7 +1113,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/release/page/2/index.html
+++ b/docs/tags/release/page/2/index.html
@@ -1007,7 +1007,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1069,7 +1069,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1104,7 +1104,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1133,7 +1133,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/release/page/3/index.html
+++ b/docs/tags/release/page/3/index.html
@@ -800,7 +800,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -862,7 +862,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -897,7 +897,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -926,7 +926,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/replication/index.html
+++ b/docs/tags/replication/index.html
@@ -473,7 +473,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -535,7 +535,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -570,7 +570,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -599,7 +599,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/restore/index.html
+++ b/docs/tags/restore/index.html
@@ -783,7 +783,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -845,7 +845,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -880,7 +880,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -909,7 +909,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/right-join/index.html
+++ b/docs/tags/right-join/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/rising/index.html
+++ b/docs/tags/rising/index.html
@@ -422,7 +422,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -484,7 +484,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -519,7 +519,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -548,7 +548,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/rollup/index.html
+++ b/docs/tags/rollup/index.html
@@ -407,7 +407,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -469,7 +469,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -504,7 +504,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -533,7 +533,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/ruby/index.html
+++ b/docs/tags/ruby/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/sample/index.html
+++ b/docs/tags/sample/index.html
@@ -408,7 +408,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -470,7 +470,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -505,7 +505,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -534,7 +534,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/scope/index.html
+++ b/docs/tags/scope/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/setup/index.html
+++ b/docs/tags/setup/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/skytools/index.html
+++ b/docs/tags/skytools/index.html
@@ -992,7 +992,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1089,7 +1089,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1118,7 +1118,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/skytools/page/2/index.html
+++ b/docs/tags/skytools/page/2/index.html
@@ -998,7 +998,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1060,7 +1060,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1095,7 +1095,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1124,7 +1124,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/skytools/page/3/index.html
+++ b/docs/tags/skytools/page/3/index.html
@@ -480,7 +480,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -542,7 +542,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -577,7 +577,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -606,7 +606,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/slave/index.html
+++ b/docs/tags/slave/index.html
@@ -404,7 +404,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -466,7 +466,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -501,7 +501,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -530,7 +530,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/solver/index.html
+++ b/docs/tags/solver/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/sql/index.html
+++ b/docs/tags/sql/index.html
@@ -1054,7 +1054,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1116,7 +1116,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1151,7 +1151,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1180,7 +1180,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/sql/page/2/index.html
+++ b/docs/tags/sql/page/2/index.html
@@ -497,7 +497,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -559,7 +559,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -594,7 +594,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -623,7 +623,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/srf/index.html
+++ b/docs/tags/srf/index.html
@@ -413,7 +413,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -475,7 +475,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -510,7 +510,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -539,7 +539,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/statistics/index.html
+++ b/docs/tags/statistics/index.html
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -538,7 +538,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -573,7 +573,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -602,7 +602,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/stock/index.html
+++ b/docs/tags/stock/index.html
@@ -422,7 +422,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -484,7 +484,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -519,7 +519,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -548,7 +548,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/sudoku/index.html
+++ b/docs/tags/sudoku/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/surrogate-keys/index.html
+++ b/docs/tags/surrogate-keys/index.html
@@ -410,7 +410,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -472,7 +472,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -507,7 +507,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -536,7 +536,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/sustainable/index.html
+++ b/docs/tags/sustainable/index.html
@@ -412,7 +412,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -474,7 +474,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -509,7 +509,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -538,7 +538,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/switch-window/index.html
+++ b/docs/tags/switch-window/index.html
@@ -784,7 +784,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -846,7 +846,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -881,7 +881,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -910,7 +910,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/templates/index.html
+++ b/docs/tags/templates/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/testing/index.html
+++ b/docs/tags/testing/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/text-processing/index.html
+++ b/docs/tags/text-processing/index.html
@@ -409,7 +409,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -471,7 +471,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -506,7 +506,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -535,7 +535,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/text/index.html
+++ b/docs/tags/text/index.html
@@ -482,7 +482,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -544,7 +544,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -579,7 +579,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -608,7 +608,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/time-zone/index.html
+++ b/docs/tags/time-zone/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/time/index.html
+++ b/docs/tags/time/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/timestamp/index.html
+++ b/docs/tags/timestamp/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/tricks/index.html
+++ b/docs/tags/tricks/index.html
@@ -829,7 +829,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -891,7 +891,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -926,7 +926,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -955,7 +955,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/triggers/index.html
+++ b/docs/tags/triggers/index.html
@@ -310,7 +310,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -589,7 +589,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -651,7 +651,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -686,7 +686,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -715,7 +715,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/triggers/index.xml
+++ b/docs/tags/triggers/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we

--- a/docs/tags/tsung/index.html
+++ b/docs/tags/tsung/index.html
@@ -398,7 +398,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -460,7 +460,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -495,7 +495,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -524,7 +524,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/unicode/index.html
+++ b/docs/tags/unicode/index.html
@@ -405,7 +405,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -467,7 +467,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -502,7 +502,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -531,7 +531,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/update/index.html
+++ b/docs/tags/update/index.html
@@ -308,7 +308,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -476,7 +476,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -538,7 +538,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -573,7 +573,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -602,7 +602,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/update/index.xml
+++ b/docs/tags/update/index.xml
@@ -25,7 +25,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 

--- a/docs/tags/walmgr/index.html
+++ b/docs/tags/walmgr/index.html
@@ -400,7 +400,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -462,7 +462,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -497,7 +497,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -526,7 +526,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/window-functions/index.html
+++ b/docs/tags/window-functions/index.html
@@ -728,7 +728,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -790,7 +790,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -825,7 +825,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -854,7 +854,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/with/index.html
+++ b/docs/tags/with/index.html
@@ -411,7 +411,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -473,7 +473,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -508,7 +508,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -537,7 +537,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/xml/index.html
+++ b/docs/tags/xml/index.html
@@ -406,7 +406,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -468,7 +468,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -503,7 +503,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -532,7 +532,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/index.html
+++ b/docs/tags/yesql/index.html
@@ -310,7 +310,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -418,7 +418,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -499,7 +499,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -574,7 +574,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p>
       <p>
         <a href="https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/" class="postShorten-excerpt_link link"></a>
@@ -1108,7 +1108,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1170,7 +1170,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1205,7 +1205,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1234,7 +1234,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/index.xml
+++ b/docs/tags/yesql/index.xml
@@ -27,7 +27,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like and
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, we
@@ -81,7 +81,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt; tweet their own lines in our
-database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;, and having had them like a
 retweet a lot in &lt;a href=&#34;https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/&#34;&gt;PostgreSQL Concurrency: Isolation and
 Locking&lt;/a&gt;, it&amp;rsquo;s
@@ -108,7 +108,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.&lt;/p&gt;
 &lt;p&gt;Today&amp;rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a &lt;em&gt;tweet&lt;/em&gt; like application. After
 having had all the characters from Shakespeare&amp;rsquo;s &lt;em&gt;A Midsummer Night&amp;rsquo;s Dream&lt;/em&gt;
-tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data
+tweet their own lines in our database in &lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data
 Modification Language&lt;/a&gt;, it&amp;rsquo;s time for them
 to do some actions on the tweets: likes and retweet.&lt;/p&gt;
 
@@ -129,7 +129,7 @@ maintains consistency while allowing concurrent operations.&lt;/p&gt;
 
 &lt;p&gt;This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-&lt;a href=&#34;https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md&#34;&gt;PostgreSQL Concurrency: Data Modification
+&lt;a href=&#34;https://tapoueh.org/blog/2018/06/postgresql-concurrency-data-modification-language/&#34;&gt;PostgreSQL Concurrency: Data Modification
 Language&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     

--- a/docs/tags/yesql/page/2/index.html
+++ b/docs/tags/yesql/page/2/index.html
@@ -1081,7 +1081,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1143,7 +1143,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1178,7 +1178,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1207,7 +1207,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/3/index.html
+++ b/docs/tags/yesql/page/3/index.html
@@ -1098,7 +1098,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1160,7 +1160,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1195,7 +1195,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1224,7 +1224,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/4/index.html
+++ b/docs/tags/yesql/page/4/index.html
@@ -1069,7 +1069,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1131,7 +1131,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1166,7 +1166,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1195,7 +1195,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/5/index.html
+++ b/docs/tags/yesql/page/5/index.html
@@ -1037,7 +1037,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1099,7 +1099,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1134,7 +1134,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1163,7 +1163,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/6/index.html
+++ b/docs/tags/yesql/page/6/index.html
@@ -1097,7 +1097,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1159,7 +1159,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1194,7 +1194,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1223,7 +1223,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/7/index.html
+++ b/docs/tags/yesql/page/7/index.html
@@ -1018,7 +1018,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -1080,7 +1080,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -1115,7 +1115,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -1144,7 +1144,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>

--- a/docs/tags/yesql/page/8/index.html
+++ b/docs/tags/yesql/page/8/index.html
@@ -736,7 +736,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like and
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, we
@@ -798,7 +798,7 @@ was a primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did in the
 previous articles in our series. After having had all the characters from
 Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em> tweet their own lines in our
-database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>, and having had them like a
 retweet a lot in <a href="/blog/2018/07/postgresql-concurrency-isolation-and-locking/">PostgreSQL Concurrency: Isolation and
 Locking</a>, it&rsquo;s
@@ -833,7 +833,7 @@ primer on PostgreSQL isolation and locking properties and behaviors.</p>
 <p>Today&rsquo;s article takes us a step further and builds on what we did last week,
 in particular the database modeling for a <em>tweet</em> like application. After
 having had all the characters from Shakespeare&rsquo;s <em>A Midsummer Night&rsquo;s Dream</em>
-tweet their own lines in our database in <a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data
+tweet their own lines in our database in <a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data
 Modification Language</a>, it&rsquo;s time for them
 to do some actions on the tweets: likes and retweet.</p>
 
@@ -862,7 +862,7 @@ maintains consistency while allowing concurrent operations.</p>
 
 <p>This article is a primer on PostgreSQL Isolation and Locking properties and
 behaviors. You might be interested into the previous article in the series:
-<a href="/blog/2018/06/PostgreSQL-DML.md">PostgreSQL Concurrency: Data Modification
+<a href="/blog/2018/06/postgresql-concurrency-data-modification-language/">PostgreSQL Concurrency: Data Modification
 Language</a>.</p></div>
             </div>
             <div style="clear:both;"></div>


### PR DESCRIPTION
As I was browsing your -amazing- blog posts, I stumbled on a broken link on 
https://tapoueh.org/blog/2018/07/postgresql-concurrency-isolation-and-locking/ which was pointing to https://tapoueh.org/blog/2018/06/PostgreSQL-DML.md

I went and changed all the occurrences of
> /blog/2018/06/PostgreSQL-DML.md 

to 

> /blog/2018/06/postgresql-concurrency-data-modification-language/

I don't know if it's the best way and if everything works, If I did wrong please let me know :)