### PR TITLE
Fix: four factual errors in pg-since-11 article

### DIFF
--- a/content/post/2026/07/pg-since-11/fig-partition-timeline.svg
+++ b/content/post/2026/07/pg-since-11/fig-partition-timeline.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="362.794pt" height="166.936pt" viewBox="0 0 362.794 166.936">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500.353pt" height="184.401pt" viewBox="0 0 500.353 184.401">
 <defs>
 <g>
 <g id="glyph-0-0">
@@ -31,6 +31,12 @@
 </g>
 <g id="glyph-0-9">
 <path d="M 3.59375 -3.203125 L 2.359375 -3.203125 L 1.265625 -3.21875 C 1.140625 -3.21875 1.125 -3.28125 1.109375 -3.328125 L 0.703125 -3.328125 L 0.484375 -2.15625 L 0.90625 -2.15625 C 0.921875 -2.265625 0.953125 -2.359375 1.015625 -2.453125 C 1.046875 -2.484375 1.046875 -2.484375 1.09375 -2.484375 C 1.21875 -2.5 1.4375 -2.5 1.609375 -2.5 L 2.515625 -2.5 C 2.15625 -2.171875 2.03125 -2.0625 1.875 -1.84375 C 1.375 -1.1875 1.3125 -0.59375 1.3125 -0.328125 C 1.3125 0.0625 1.640625 0.078125 1.6875 0.078125 C 1.84375 0.078125 1.921875 0.015625 1.953125 -0.015625 C 2.0625 -0.125 2.0625 -0.25 2.0625 -0.34375 C 2.078125 -1.546875 2.40625 -1.859375 2.734375 -2.15625 L 3.046875 -2.4375 L 3.546875 -2.90625 C 3.5625 -2.921875 3.578125 -2.9375 3.59375 -2.96875 C 3.59375 -2.984375 3.59375 -3.125 3.59375 -3.203125 Z M 3.59375 -3.203125 "/>
+</g>
+<g id="glyph-0-10">
+<path d="M 3.390625 -0.921875 C 3.390625 -1.3125 3.125 -1.625 2.625 -1.828125 C 3.078125 -2.03125 3.1875 -2.296875 3.1875 -2.53125 C 3.1875 -3.25 2.3125 -3.296875 1.90625 -3.296875 C 1.359375 -3.296875 0.59375 -3.140625 0.59375 -2.390625 C 0.59375 -1.984375 0.921875 -1.75 1.09375 -1.65625 C 0.71875 -1.515625 0.390625 -1.28125 0.390625 -0.8125 C 0.390625 0.03125 1.359375 0.078125 1.875 0.078125 C 2.125 0.078125 3.390625 0.078125 3.390625 -0.921875 Z M 2.6875 -2.515625 C 2.6875 -2.28125 2.53125 -2.109375 2.25 -2 L 1.546875 -2.3125 C 1.203125 -2.46875 1.09375 -2.515625 1.09375 -2.671875 C 1.09375 -2.890625 1.265625 -3.015625 1.859375 -3.015625 C 2.171875 -3.015625 2.6875 -2.96875 2.6875 -2.515625 Z M 2.8125 -0.671875 C 2.8125 -0.390625 2.59375 -0.21875 1.90625 -0.21875 C 1.515625 -0.21875 0.96875 -0.296875 0.96875 -0.8125 C 0.96875 -1.125 1.15625 -1.328125 1.515625 -1.46875 L 2.5 -1.03125 C 2.53125 -1.03125 2.8125 -0.90625 2.8125 -0.671875 Z M 2.8125 -0.671875 "/>
+</g>
+<g id="glyph-0-11">
+<path d="M 3.390625 -1.640625 C 3.390625 -2.640625 2.953125 -3.296875 1.90625 -3.296875 C 1.515625 -3.296875 1.21875 -3.25 0.890625 -3.0625 C 0.5 -2.8125 0.390625 -2.515625 0.390625 -2.1875 C 0.390625 -1.53125 0.921875 -1.09375 1.765625 -1.09375 C 2.171875 -1.09375 2.4375 -1.28125 2.609375 -1.5 C 2.609375 -1.203125 2.609375 -0.84375 2.40625 -0.578125 C 2.15625 -0.25 1.765625 -0.21875 1.578125 -0.21875 C 1.53125 -0.21875 1.328125 -0.21875 1.171875 -0.296875 C 1.171875 -0.296875 1.3125 -0.40625 1.3125 -0.609375 C 1.3125 -0.84375 1.140625 -0.984375 0.9375 -0.984375 C 0.765625 -0.984375 0.5625 -0.875 0.5625 -0.59375 C 0.5625 0.078125 1.421875 0.078125 1.59375 0.078125 C 2.625 0.078125 3.390625 -0.53125 3.390625 -1.640625 Z M 2.59375 -2.15625 C 2.59375 -1.65625 2.234375 -1.375 1.828125 -1.375 C 1.171875 -1.375 1.171875 -1.78125 1.171875 -2.1875 C 1.171875 -2.578125 1.171875 -3.015625 1.90625 -3.015625 C 2.53125 -3.015625 2.59375 -2.53125 2.59375 -2.15625 Z M 2.59375 -2.15625 "/>
 </g>
 <g id="glyph-1-0">
 <path d="M 3.5625 -4.46875 C 3.53125 -4.5 3.46875 -4.5625 3.390625 -4.484375 C 3.3125 -4.40625 3.359375 -4.359375 3.40625 -4.3125 C 3.65625 -4 3.625 -3.71875 3.46875 -3.5625 C 3.1875 -3.28125 2.859375 -3.515625 2.375 -3.90625 C 1.90625 -4.25 1.828125 -4.328125 1.5 -4.34375 C 1.40625 -4.34375 1.125 -4.34375 0.796875 -4.140625 C 1.140625 -4.703125 1.28125 -5.4375 0.890625 -5.828125 C 0.390625 -6.328125 -0.671875 -6.078125 -1.4375 -5.3125 L -3.09375 -3.65625 L -2.90625 -3.46875 L -2.78125 -3.59375 C -2.40625 -3.96875 -2.34375 -3.9375 -2.171875 -3.765625 L 0.40625 -1.1875 C 0.5625 -1.03125 0.609375 -0.953125 0.234375 -0.578125 L 0.109375 -0.453125 L 0.28125 -0.28125 L 1 -1.03125 L 1.75 -1.75 L 1.578125 -1.921875 L 1.46875 -1.8125 C 1.078125 -1.421875 1 -1.46875 0.84375 -1.625 L -0.375 -2.84375 L 0.296875 -3.515625 C 0.375 -3.59375 0.640625 -3.859375 1.046875 -3.890625 C 1.359375 -3.890625 1.484375 -3.765625 1.8125 -3.4375 C 2.140625 -3.109375 2.34375 -2.90625 2.765625 -2.953125 C 3.15625 -3 3.453125 -3.265625 3.59375 -3.40625 C 4.015625 -3.828125 3.71875 -4.3125 3.5625 -4.46875 Z M 0.359375 -5.296875 C 0.90625 -4.75 0.65625 -4.15625 0.125 -3.625 L -0.515625 -2.984375 L -1.765625 -4.234375 C -1.90625 -4.375 -1.921875 -4.421875 -1.8125 -4.5625 C -1.765625 -4.609375 -1.609375 -4.765625 -1.5 -4.875 C -1.03125 -5.34375 -0.359375 -6.015625 0.359375 -5.296875 Z M 0.359375 -5.296875 "/>
@@ -163,429 +169,450 @@
 </g>
 </g>
 </defs>
-<path fill="none" stroke-width="0.79701" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(75%, 75%, 75%)" stroke-opacity="1" stroke-miterlimit="10" d="M -8.5035 0.00071875 L 295.812906 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill-rule="nonzero" fill="rgb(75%, 75%, 75%)" fill-opacity="1" d="M 317.417969 147.988281 C 316.035156 147.730469 313.789062 146.953125 312.238281 146.046875 L 312.238281 149.933594 C 313.789062 149.023438 316.035156 148.246094 317.417969 147.988281 "/>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 0.00040625 -3.401625 L 0.00040625 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.79701" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(75%, 75%, 75%)" stroke-opacity="1" stroke-miterlimit="10" d="M -8.5035 0.000875 L 380.855875 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill-rule="nonzero" fill="rgb(75%, 75%, 75%)" fill-opacity="1" d="M 402.457031 165.453125 C 401.078125 165.195312 398.832031 164.417969 397.277344 163.511719 L 397.277344 167.398438 C 398.832031 166.488281 401.078125 165.714844 402.457031 165.453125 "/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 0.00040625 -3.401469 L 0.00040625 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="7.306" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="12.372002" y="159.546"/>
+<use xlink:href="#glyph-0-0" x="7.306" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="12.372002" y="177.011"/>
 </g>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="19.022065" y="159.546"/>
-<use xlink:href="#glyph-0-3" x="22.797905" y="159.546"/>
+<use xlink:href="#glyph-0-2" x="19.022065" y="177.011"/>
+<use xlink:href="#glyph-0-3" x="22.797905" y="177.011"/>
 </g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 39.684 -3.401625 L 39.684 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 39.684 -3.401469 L 39.684 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="46.99" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="52.056002" y="159.546"/>
-</g>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="58.706065" y="159.546"/>
-<use xlink:href="#glyph-0-2" x="62.481905" y="159.546"/>
-</g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 79.3715 -3.401625 L 79.3715 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="86.675" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="91.741002" y="159.546"/>
+<use xlink:href="#glyph-0-0" x="46.99" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="52.056002" y="177.011"/>
 </g>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="98.391065" y="159.546"/>
-<use xlink:href="#glyph-0-4" x="102.166905" y="159.546"/>
+<use xlink:href="#glyph-0-2" x="58.706065" y="177.011"/>
+<use xlink:href="#glyph-0-2" x="62.481905" y="177.011"/>
 </g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 119.055094 -3.401625 L 119.055094 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 79.3715 -3.401469 L 79.3715 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="126.36" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="131.426002" y="159.546"/>
-</g>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="138.076065" y="159.546"/>
-<use xlink:href="#glyph-0-5" x="141.851905" y="159.546"/>
-</g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 158.742594 -3.401625 L 158.742594 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="166.045" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="171.111002" y="159.546"/>
+<use xlink:href="#glyph-0-0" x="86.675" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="91.741002" y="177.011"/>
 </g>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="177.761065" y="159.546"/>
-<use xlink:href="#glyph-0-6" x="181.536905" y="159.546"/>
+<use xlink:href="#glyph-0-2" x="98.391065" y="177.011"/>
+<use xlink:href="#glyph-0-4" x="102.166905" y="177.011"/>
 </g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 198.426187 -3.401625 L 198.426187 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 119.055094 -3.401469 L 119.055094 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="205.73" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="210.796002" y="159.546"/>
-</g>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="217.446065" y="159.546"/>
-<use xlink:href="#glyph-0-7" x="221.221905" y="159.546"/>
-</g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 238.113687 -3.401625 L 238.113687 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="245.415" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="250.481002" y="159.546"/>
+<use xlink:href="#glyph-0-0" x="126.36" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="131.426002" y="177.011"/>
 </g>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="257.131065" y="159.546"/>
-<use xlink:href="#glyph-0-8" x="260.906905" y="159.546"/>
+<use xlink:href="#glyph-0-2" x="138.076065" y="177.011"/>
+<use xlink:href="#glyph-0-5" x="141.851905" y="177.011"/>
 </g>
-<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 277.797281 -3.401625 L 277.797281 3.403063 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 158.742594 -3.401469 L 158.742594 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-0" x="285.1" y="159.546"/>
-<use xlink:href="#glyph-0-1" x="290.166002" y="159.546"/>
+<use xlink:href="#glyph-0-0" x="166.045" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="171.111002" y="177.011"/>
 </g>
 <g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
-<use xlink:href="#glyph-0-2" x="296.816065" y="159.546"/>
-<use xlink:href="#glyph-0-9" x="300.591905" y="159.546"/>
+<use xlink:href="#glyph-0-2" x="177.761065" y="177.011"/>
+<use xlink:href="#glyph-0-6" x="181.536905" y="177.011"/>
 </g>
-<path fill-rule="nonzero" fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 2.789469 0.00071875 C 2.789469 1.539781 1.539469 2.789781 0.00040625 2.789781 C -1.542562 2.789781 -2.788656 1.539781 -2.788656 0.00071875 C -2.788656 -1.54225 -1.542562 -2.788344 0.00040625 -2.788344 C 1.539469 -2.788344 2.789469 -1.54225 2.789469 0.00071875 Z M 2.789469 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 0.00040625 0.00071875 L 0.00040625 39.684313 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 198.426187 -3.401469 L 198.426187 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-0" x="205.73" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="210.796002" y="177.011"/>
+</g>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="217.446065" y="177.011"/>
+<use xlink:href="#glyph-0-7" x="221.221905" y="177.011"/>
+</g>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 238.113687 -3.401469 L 238.113687 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-0" x="245.415" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="250.481002" y="177.011"/>
+</g>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="257.131065" y="177.011"/>
+<use xlink:href="#glyph-0-8" x="260.906905" y="177.011"/>
+</g>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 277.797281 -3.401469 L 277.797281 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-0" x="285.1" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="290.166002" y="177.011"/>
+</g>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="296.816065" y="177.011"/>
+<use xlink:href="#glyph-0-9" x="300.591905" y="177.011"/>
+</g>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 317.484781 -3.401469 L 317.484781 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-0" x="324.784" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="329.850002" y="177.011"/>
+</g>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="336.500065" y="177.011"/>
+<use xlink:href="#glyph-0-10" x="340.275905" y="177.011"/>
+</g>
+<path fill="none" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 69.999695%, 69.999695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 357.168375 -3.401469 L 357.168375 3.403219 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-0" x="364.469" y="177.011"/>
+<use xlink:href="#glyph-0-1" x="369.535002" y="177.011"/>
+</g>
+<g fill="rgb(50%, 50%, 50%)" fill-opacity="1">
+<use xlink:href="#glyph-0-2" x="376.185065" y="177.011"/>
+<use xlink:href="#glyph-0-11" x="379.960905" y="177.011"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 2.789469 0.000875 C 2.789469 1.539938 1.539469 2.789938 0.00040625 2.789938 C -1.542562 2.789938 -2.788656 1.539938 -2.788656 0.000875 C -2.788656 -1.542094 -1.542562 -2.788187 0.00040625 -2.788187 C 1.539469 -2.788187 2.789469 -1.542094 2.789469 0.000875 Z M 2.789469 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 0.00040625 0.000875 L 0.00040625 39.684469 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-0" x="17.631" y="101.181"/>
-<use xlink:href="#glyph-1-1" x="21.718973" y="97.093027"/>
-<use xlink:href="#glyph-1-2" x="25.875982" y="92.936018"/>
-<use xlink:href="#glyph-1-3" x="30.032991" y="88.779009"/>
-<use xlink:href="#glyph-1-4" x="34.392181" y="84.419819"/>
+<use xlink:href="#glyph-1-0" x="17.631" y="118.646"/>
+<use xlink:href="#glyph-1-1" x="21.718973" y="114.558027"/>
+<use xlink:href="#glyph-1-2" x="25.875982" y="110.401018"/>
+<use xlink:href="#glyph-1-3" x="30.032991" y="106.244009"/>
+<use xlink:href="#glyph-1-4" x="34.392181" y="101.884819"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-5" x="40.077865" y="78.734135"/>
+<use xlink:href="#glyph-1-5" x="40.077865" y="96.199135"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-6" x="46.301051" y="72.510949"/>
-<use xlink:href="#glyph-1-7" x="49.782485" y="69.029515"/>
-<use xlink:href="#glyph-1-8" x="51.819074" y="66.992926"/>
-<use xlink:href="#glyph-1-9" x="54.930667" y="63.881333"/>
+<use xlink:href="#glyph-1-6" x="46.301051" y="89.975949"/>
+<use xlink:href="#glyph-1-7" x="49.782485" y="86.494515"/>
+<use xlink:href="#glyph-1-8" x="51.819074" y="84.457926"/>
+<use xlink:href="#glyph-1-9" x="54.930667" y="81.346333"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="60.85305" y="57.95895"/>
-<use xlink:href="#glyph-1-11" x="63.964643" y="54.847357"/>
-<use xlink:href="#glyph-1-12" x="66.770501" y="52.041499"/>
-<use xlink:href="#glyph-1-13" x="68.96982" y="49.84218"/>
-<use xlink:href="#glyph-1-14" x="71.16914" y="47.64286"/>
-<use xlink:href="#glyph-1-13" x="72.76192" y="46.05008"/>
-<use xlink:href="#glyph-1-14" x="74.96124" y="43.85076"/>
-<use xlink:href="#glyph-1-15" x="76.55402" y="42.25798"/>
-<use xlink:href="#glyph-1-16" x="79.359878" y="39.452122"/>
-<use xlink:href="#glyph-1-14" x="82.471472" y="36.340528"/>
-<use xlink:href="#glyph-1-16" x="84.064252" y="34.747748"/>
-<use xlink:href="#glyph-1-17" x="87.175845" y="31.636155"/>
+<use xlink:href="#glyph-1-10" x="60.85305" y="75.42395"/>
+<use xlink:href="#glyph-1-11" x="63.964643" y="72.312357"/>
+<use xlink:href="#glyph-1-12" x="66.770501" y="69.506499"/>
+<use xlink:href="#glyph-1-13" x="68.96982" y="67.30718"/>
+<use xlink:href="#glyph-1-14" x="71.16914" y="65.10786"/>
+<use xlink:href="#glyph-1-13" x="72.76192" y="63.51508"/>
+<use xlink:href="#glyph-1-14" x="74.96124" y="61.31576"/>
+<use xlink:href="#glyph-1-15" x="76.55402" y="59.72298"/>
+<use xlink:href="#glyph-1-16" x="79.359878" y="56.917122"/>
+<use xlink:href="#glyph-1-14" x="82.471472" y="53.805528"/>
+<use xlink:href="#glyph-1-16" x="84.064252" y="52.212748"/>
+<use xlink:href="#glyph-1-17" x="87.175845" y="49.101155"/>
 </g>
-<path fill-rule="nonzero" fill="rgb(0%, 50%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 41.059 0.00071875 C 41.059 1.539781 39.809 2.789781 38.269937 2.789781 C 36.726969 2.789781 35.476969 1.539781 35.476969 0.00071875 C 35.476969 -1.54225 36.726969 -2.788344 38.269937 -2.788344 C 39.809 -2.788344 41.059 -1.54225 41.059 0.00071875 Z M 41.059 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 38.269937 0.00071875 L 38.269937 56.692125 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<path fill-rule="nonzero" fill="rgb(0%, 50%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 41.059 0.000875 C 41.059 1.539938 39.809 2.789938 38.269937 2.789938 C 36.726969 2.789938 35.476969 1.539938 35.476969 0.000875 C 35.476969 -1.542094 36.726969 -2.788187 38.269937 -2.788187 C 39.809 -2.788187 41.059 -1.542094 41.059 0.000875 Z M 41.059 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 38.269937 0.000875 L 38.269937 56.692281 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-3" x="56.811" y="85.086"/>
-<use xlink:href="#glyph-1-18" x="61.170189" y="80.726811"/>
-<use xlink:href="#glyph-1-15" x="62.76297" y="79.13403"/>
-<use xlink:href="#glyph-1-19" x="65.568828" y="76.328172"/>
-<use xlink:href="#glyph-1-11" x="68.680421" y="73.216579"/>
-<use xlink:href="#glyph-1-18" x="71.486279" y="70.410721"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-14" x="74.977575" y="66.919425"/>
-<use xlink:href="#glyph-1-16" x="76.570356" y="65.326644"/>
-<use xlink:href="#glyph-1-20" x="79.681949" y="62.215051"/>
-<use xlink:href="#glyph-1-21" x="82.793542" y="59.103458"/>
-<use xlink:href="#glyph-1-22" x="85.298596" y="56.598404"/>
-<use xlink:href="#glyph-1-21" x="88.257322" y="53.639678"/>
-<use xlink:href="#glyph-1-23" x="90.762376" y="51.134624"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-24" x="94.89473" y="47.00227"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-25" x="101.117916" y="40.779084"/>
-<use xlink:href="#glyph-1-26" x="104.905085" y="36.991915"/>
-<use xlink:href="#glyph-1-23" x="109.214962" y="32.682038"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-24" x="113.347315" y="28.549685"/>
+<use xlink:href="#glyph-1-3" x="56.811" y="102.551"/>
+<use xlink:href="#glyph-1-18" x="61.170189" y="98.191811"/>
+<use xlink:href="#glyph-1-15" x="62.76297" y="96.59903"/>
+<use xlink:href="#glyph-1-19" x="65.568828" y="93.793172"/>
+<use xlink:href="#glyph-1-11" x="68.680421" y="90.681579"/>
+<use xlink:href="#glyph-1-18" x="71.486279" y="87.875721"/>
 </g>
 <g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-27" x="119.570501" y="22.326499"/>
-<use xlink:href="#glyph-1-26" x="123.204802" y="18.692198"/>
-<use xlink:href="#glyph-1-23" x="127.514679" y="14.382321"/>
+<use xlink:href="#glyph-1-14" x="74.977575" y="84.384425"/>
+<use xlink:href="#glyph-1-16" x="76.570356" y="82.791644"/>
+<use xlink:href="#glyph-1-20" x="79.681949" y="79.680051"/>
+<use xlink:href="#glyph-1-21" x="82.793542" y="76.568458"/>
+<use xlink:href="#glyph-1-22" x="85.298596" y="74.063404"/>
+<use xlink:href="#glyph-1-21" x="88.257322" y="71.104678"/>
+<use xlink:href="#glyph-1-23" x="90.762376" y="68.599624"/>
 </g>
-<path fill-rule="nonzero" fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 43.891031 0.00071875 C 43.891031 1.539781 42.644937 2.789781 41.101969 2.789781 C 39.562906 2.789781 38.312906 1.539781 38.312906 0.00071875 C 38.312906 -1.54225 39.562906 -2.788344 41.101969 -2.788344 C 42.644937 -2.788344 43.891031 -1.54225 43.891031 0.00071875 Z M 43.891031 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 41.101969 0.00071875 L 41.101969 22.6765 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-28" x="58.787" y="118.243"/>
-<use xlink:href="#glyph-1-1" x="62.944009" y="114.085991"/>
-<use xlink:href="#glyph-1-8" x="67.101019" y="109.928981"/>
-<use xlink:href="#glyph-1-28" x="70.212612" y="106.817388"/>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-24" x="94.89473" y="64.46727"/>
 </g>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-24" x="76.268137" y="100.761863"/>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-25" x="101.117916" y="58.244084"/>
+<use xlink:href="#glyph-1-26" x="104.905085" y="54.456915"/>
+<use xlink:href="#glyph-1-23" x="109.214962" y="50.147038"/>
 </g>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-29" x="82.491323" y="94.538677"/>
-<use xlink:href="#glyph-1-25" x="86.648333" y="90.381667"/>
-<use xlink:href="#glyph-1-30" x="90.435502" y="86.594498"/>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-24" x="113.347315" y="46.014685"/>
 </g>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="94.528405" y="82.501595"/>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-27" x="119.570501" y="39.791499"/>
+<use xlink:href="#glyph-1-26" x="123.204802" y="36.157198"/>
+<use xlink:href="#glyph-1-23" x="127.514679" y="31.847321"/>
 </g>
+<path fill-rule="nonzero" fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 43.891031 0.000875 C 43.891031 1.539938 42.644937 2.789938 41.101969 2.789938 C 39.562906 2.789938 38.312906 1.539938 38.312906 0.000875 C 38.312906 -1.542094 39.562906 -2.788187 41.101969 -2.788187 C 42.644937 -2.788187 43.891031 -1.542094 43.891031 0.000875 Z M 43.891031 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 54.998779%)" stroke-opacity="1" stroke-miterlimit="10" d="M 41.101969 0.000875 L 41.101969 22.676656 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="98.231743" y="78.798257"/>
-<use xlink:href="#glyph-1-4" x="102.25561" y="74.77439"/>
-</g>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-24" x="107.936363" y="69.093637"/>
-</g>
-<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-30" x="114.15955" y="62.87045"/>
-<use xlink:href="#glyph-1-4" x="118.40039" y="58.62961"/>
-<use xlink:href="#glyph-1-27" x="122.187558" y="54.842442"/>
+<use xlink:href="#glyph-1-28" x="58.787" y="135.708"/>
+<use xlink:href="#glyph-1-1" x="62.944009" y="131.550991"/>
+<use xlink:href="#glyph-1-8" x="67.101019" y="127.393981"/>
+<use xlink:href="#glyph-1-28" x="70.212612" y="124.282388"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="125.220252" y="51.809748"/>
+<use xlink:href="#glyph-1-24" x="76.268137" y="118.226863"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-29" x="129.224394" y="47.805606"/>
-<use xlink:href="#glyph-1-6" x="133.381404" y="43.648596"/>
+<use xlink:href="#glyph-1-29" x="82.491323" y="112.003677"/>
+<use xlink:href="#glyph-1-25" x="86.648333" y="107.846667"/>
+<use xlink:href="#glyph-1-30" x="90.435502" y="104.059498"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="136.409166" y="40.620834"/>
+<use xlink:href="#glyph-1-1" x="94.528405" y="99.966595"/>
 </g>
 <g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="142.326617" y="34.703383"/>
-<use xlink:href="#glyph-1-11" x="145.43821" y="31.59179"/>
-<use xlink:href="#glyph-1-12" x="148.244069" y="28.785931"/>
-<use xlink:href="#glyph-1-13" x="150.443388" y="26.586612"/>
-<use xlink:href="#glyph-1-14" x="152.642707" y="24.387293"/>
-<use xlink:href="#glyph-1-13" x="154.235488" y="22.794512"/>
-<use xlink:href="#glyph-1-14" x="156.434807" y="20.595193"/>
-<use xlink:href="#glyph-1-15" x="158.027588" y="19.002412"/>
-<use xlink:href="#glyph-1-16" x="160.833446" y="16.196554"/>
+<use xlink:href="#glyph-1-9" x="98.231743" y="96.263257"/>
+<use xlink:href="#glyph-1-4" x="102.25561" y="92.23939"/>
 </g>
-<path fill-rule="nonzero" fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 82.160562 0.00071875 C 82.160562 1.539781 80.910562 2.789781 79.3715 2.789781 C 77.828531 2.789781 76.582437 1.539781 76.582437 0.00071875 C 76.582437 -1.54225 77.828531 -2.788344 79.3715 -2.788344 C 80.910562 -2.788344 82.160562 -1.54225 82.160562 0.00071875 Z M 82.160562 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 79.3715 0.00071875 L 79.3715 28.348375 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-24" x="107.936363" y="86.558637"/>
+</g>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-30" x="114.15955" y="80.33545"/>
+<use xlink:href="#glyph-1-4" x="118.40039" y="76.09461"/>
+<use xlink:href="#glyph-1-27" x="122.187558" y="72.307442"/>
+</g>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-1" x="125.220252" y="69.274748"/>
+</g>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-29" x="129.224394" y="65.270606"/>
+<use xlink:href="#glyph-1-6" x="133.381404" y="61.113596"/>
+</g>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-9" x="136.409166" y="58.085834"/>
+</g>
+<g fill="rgb(0%, 0%, 54.998779%)" fill-opacity="1">
+<use xlink:href="#glyph-1-10" x="142.326617" y="52.168383"/>
+<use xlink:href="#glyph-1-11" x="145.43821" y="49.05679"/>
+<use xlink:href="#glyph-1-12" x="148.244069" y="46.250931"/>
+<use xlink:href="#glyph-1-13" x="150.443388" y="44.051612"/>
+<use xlink:href="#glyph-1-14" x="152.642707" y="41.852293"/>
+<use xlink:href="#glyph-1-13" x="154.235488" y="40.259512"/>
+<use xlink:href="#glyph-1-14" x="156.434807" y="38.060193"/>
+<use xlink:href="#glyph-1-15" x="158.027588" y="36.467412"/>
+<use xlink:href="#glyph-1-16" x="160.833446" y="33.661554"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 82.160562 0.000875 C 82.160562 1.539938 80.910562 2.789938 79.3715 2.789938 C 77.828531 2.789938 76.582437 1.539938 76.582437 0.000875 C 76.582437 -1.542094 77.828531 -2.788187 79.3715 -2.788187 C 80.910562 -2.788187 82.160562 -1.542094 82.160562 0.000875 Z M 82.160562 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 79.3715 0.000875 L 79.3715 28.348531 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-25" x="97.001" y="112.52"/>
-<use xlink:href="#glyph-1-18" x="100.788169" y="108.732831"/>
-<use xlink:href="#glyph-1-11" x="102.380949" y="107.140051"/>
-<use xlink:href="#glyph-1-16" x="105.186807" y="104.334193"/>
-<use xlink:href="#glyph-1-16" x="108.298401" y="101.222599"/>
-<use xlink:href="#glyph-1-14" x="111.409994" y="98.111006"/>
-<use xlink:href="#glyph-1-16" x="113.002774" y="96.518226"/>
-<use xlink:href="#glyph-1-17" x="116.114367" y="93.406633"/>
-<use xlink:href="#glyph-1-31" x="118.920225" y="90.600775"/>
-<use xlink:href="#glyph-1-13" x="120.818741" y="88.702259"/>
-<use xlink:href="#glyph-1-14" x="123.01806" y="86.50294"/>
-<use xlink:href="#glyph-1-32" x="124.610841" y="84.910159"/>
-<use xlink:href="#glyph-1-21" x="129.241247" y="80.279753"/>
-</g>
-<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-5" x="133.644817" y="75.876183"/>
-</g>
-<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-12" x="139.868003" y="69.652997"/>
-<use xlink:href="#glyph-1-33" x="142.067322" y="67.453678"/>
-<use xlink:href="#glyph-1-16" x="145.178915" y="64.342085"/>
-</g>
-<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-13" x="148.137641" y="61.383359"/>
-<use xlink:href="#glyph-1-14" x="150.33696" y="59.18404"/>
-<use xlink:href="#glyph-1-32" x="151.929741" y="57.591259"/>
-<use xlink:href="#glyph-1-21" x="156.560146" y="52.960854"/>
-</g>
-<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="160.963716" y="48.557284"/>
-<use xlink:href="#glyph-1-12" x="164.075309" y="45.445691"/>
-<use xlink:href="#glyph-1-33" x="166.274629" y="43.246371"/>
-<use xlink:href="#glyph-1-16" x="169.386222" y="40.134778"/>
-<use xlink:href="#glyph-1-14" x="172.497815" y="37.023185"/>
-<use xlink:href="#glyph-1-16" x="174.090596" y="35.430404"/>
-<use xlink:href="#glyph-1-17" x="177.202189" y="32.318811"/>
-</g>
-<path fill-rule="nonzero" fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 121.844156 0.00071875 C 121.844156 1.539781 120.598062 2.789781 119.055094 2.789781 C 117.516031 2.789781 116.266031 1.539781 116.266031 0.00071875 C 116.266031 -1.54225 117.516031 -2.788344 119.055094 -2.788344 C 120.598062 -2.788344 121.844156 -1.54225 121.844156 0.00071875 Z M 121.844156 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 119.055094 0.00071875 L 119.055094 17.008531 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-6" x="136.686" y="123.858"/>
-<use xlink:href="#glyph-1-15" x="140.167434" y="120.376566"/>
-<use xlink:href="#glyph-1-17" x="142.973292" y="117.570708"/>
-<use xlink:href="#glyph-1-14" x="145.77915" y="114.76485"/>
-<use xlink:href="#glyph-1-34" x="147.371931" y="113.172069"/>
-<use xlink:href="#glyph-1-11" x="149.876985" y="110.667015"/>
-<use xlink:href="#glyph-1-18" x="152.682843" y="107.861157"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-12" x="156.174139" y="104.369861"/>
-<use xlink:href="#glyph-1-21" x="158.373459" y="102.170541"/>
-<use xlink:href="#glyph-1-10" x="160.878513" y="99.665487"/>
-<use xlink:href="#glyph-1-18" x="163.990106" y="96.553894"/>
-<use xlink:href="#glyph-1-14" x="165.582887" y="94.961113"/>
-<use xlink:href="#glyph-1-34" x="167.175667" y="93.368333"/>
-<use xlink:href="#glyph-1-11" x="169.680722" y="90.863278"/>
-<use xlink:href="#glyph-1-13" x="172.48658" y="88.05742"/>
-<use xlink:href="#glyph-1-14" x="174.685899" y="85.858101"/>
-<use xlink:href="#glyph-1-15" x="176.27868" y="84.26532"/>
-<use xlink:href="#glyph-1-16" x="179.084538" y="81.459462"/>
-</g>
-<path fill-rule="nonzero" fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 161.531656 0.00071875 C 161.531656 1.539781 160.281656 2.789781 158.742594 2.789781 C 157.203531 2.789781 155.953531 1.539781 155.953531 0.00071875 C 155.953531 -1.54225 157.203531 -2.788344 158.742594 -2.788344 C 160.281656 -2.788344 161.531656 -1.54225 161.531656 0.00071875 Z M 161.531656 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 158.742594 0.00071875 L 158.742594 39.684313 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-27" x="177.284" y="102.093"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-11" x="180.46463" y="98.91237"/>
-<use xlink:href="#glyph-1-23" x="183.270488" y="96.106512"/>
-<use xlink:href="#glyph-1-13" x="185.504326" y="93.872674"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="189.59723" y="89.77977"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="193.305499" y="86.071501"/>
-<use xlink:href="#glyph-1-9" x="197.329366" y="82.047634"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="200.899562" y="78.477438"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-35" x="204.903703" y="74.473297"/>
-<use xlink:href="#glyph-1-28" x="208.92757" y="70.44943"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-25" x="214.978164" y="64.398836"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="218.316593" y="61.060407"/>
-<use xlink:href="#glyph-1-0" x="222.473602" y="56.903398"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="226.107904" y="53.269096"/>
-<use xlink:href="#glyph-1-7" x="230.13177" y="49.24523"/>
-<use xlink:href="#glyph-1-9" x="232.16836" y="47.20864"/>
-<use xlink:href="#glyph-1-7" x="236.192227" y="43.184773"/>
-<use xlink:href="#glyph-1-36" x="238.228816" y="41.148184"/>
-<use xlink:href="#glyph-1-2" x="242.553487" y="36.823513"/>
-</g>
-<path fill-rule="nonzero" fill="rgb(0%, 50%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 201.219156 0.00071875 C 201.219156 1.539781 199.969156 2.789781 198.426187 2.789781 C 196.887125 2.789781 195.637125 1.539781 195.637125 0.00071875 C 195.637125 -1.54225 196.887125 -2.788344 198.426187 -2.788344 C 199.969156 -2.788344 201.219156 -1.54225 201.219156 0.00071875 Z M 201.219156 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 198.426187 0.00071875 L 198.426187 14.172594 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-37" x="216.11" y="126.747"/>
-<use xlink:href="#glyph-1-4" x="221.179283" y="121.677717"/>
-<use xlink:href="#glyph-1-0" x="224.966452" y="117.890548"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-3" x="228.901557" y="113.955443"/>
-<use xlink:href="#glyph-1-4" x="233.260746" y="109.596254"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-24" x="238.94643" y="103.91057"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-27" x="245.169617" y="97.687383"/>
-<use xlink:href="#glyph-1-26" x="248.803918" y="94.053082"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-38" x="255.01231" y="87.84469"/>
-<use xlink:href="#glyph-1-12" x="256.757959" y="86.099041"/>
-<use xlink:href="#glyph-1-15" x="258.957278" y="83.899722"/>
-<use xlink:href="#glyph-1-32" x="261.763136" y="81.093864"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="268.292057" y="74.564943"/>
-<use xlink:href="#glyph-1-11" x="271.40365" y="71.45335"/>
-<use xlink:href="#glyph-1-12" x="274.209508" y="68.647492"/>
-<use xlink:href="#glyph-1-13" x="276.408828" y="66.448172"/>
-<use xlink:href="#glyph-1-14" x="278.608147" y="64.248853"/>
-<use xlink:href="#glyph-1-13" x="280.200928" y="62.656072"/>
-<use xlink:href="#glyph-1-14" x="282.400247" y="60.456753"/>
-<use xlink:href="#glyph-1-15" x="283.993028" y="58.863972"/>
-<use xlink:href="#glyph-1-16" x="286.798886" y="56.058114"/>
-<use xlink:href="#glyph-1-21" x="289.910479" y="52.946521"/>
-<use xlink:href="#glyph-1-20" x="292.415533" y="50.441467"/>
-</g>
-<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-13" x="297.425642" y="45.431358"/>
-<use xlink:href="#glyph-1-11" x="299.624961" y="43.232039"/>
-<use xlink:href="#glyph-1-19" x="302.430819" y="40.426181"/>
-<use xlink:href="#glyph-1-18" x="305.542412" y="37.314588"/>
-<use xlink:href="#glyph-1-21" x="307.135193" y="35.721807"/>
-</g>
-<path fill-rule="nonzero" fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 240.90275 0.00071875 C 240.90275 1.539781 239.65275 2.789781 238.113687 2.789781 C 236.570719 2.789781 235.324625 1.539781 235.324625 0.00071875 C 235.324625 -1.54225 236.570719 -2.788344 238.113687 -2.788344 C 239.65275 -2.788344 240.90275 -1.54225 240.90275 0.00071875 Z M 240.90275 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 238.113687 0.00071875 L 238.113687 36.852281 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="255.524" y="103.799"/>
-<use xlink:href="#glyph-1-2" x="259.681009" y="99.641991"/>
-<use xlink:href="#glyph-1-39" x="263.838019" y="95.484981"/>
-<use xlink:href="#glyph-1-40" x="267.995028" y="91.327972"/>
-<use xlink:href="#glyph-1-11" x="270.194348" y="89.128652"/>
-<use xlink:href="#glyph-1-12" x="273.000206" y="86.322794"/>
-<use xlink:href="#glyph-1-12" x="275.199525" y="84.123475"/>
-<use xlink:href="#glyph-1-11" x="277.398845" y="81.924155"/>
+<use xlink:href="#glyph-1-25" x="97.001" y="129.985"/>
+<use xlink:href="#glyph-1-18" x="100.788169" y="126.197831"/>
+<use xlink:href="#glyph-1-11" x="102.380949" y="124.605051"/>
+<use xlink:href="#glyph-1-16" x="105.186807" y="121.799193"/>
+<use xlink:href="#glyph-1-16" x="108.298401" y="118.687599"/>
+<use xlink:href="#glyph-1-14" x="111.409994" y="115.576006"/>
+<use xlink:href="#glyph-1-16" x="113.002774" y="113.983226"/>
+<use xlink:href="#glyph-1-17" x="116.114367" y="110.871633"/>
+<use xlink:href="#glyph-1-31" x="118.920225" y="108.065775"/>
+<use xlink:href="#glyph-1-13" x="120.818741" y="106.167259"/>
+<use xlink:href="#glyph-1-14" x="123.01806" y="103.96794"/>
+<use xlink:href="#glyph-1-32" x="124.610841" y="102.375159"/>
+<use xlink:href="#glyph-1-21" x="129.241247" y="97.744753"/>
 </g>
 <g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-41" x="280.056766" y="79.266234"/>
-<use xlink:href="#glyph-1-42" x="283.015492" y="76.307508"/>
+<use xlink:href="#glyph-1-5" x="133.644817" y="93.341183"/>
 </g>
 <g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="287.108396" y="72.214604"/>
-<use xlink:href="#glyph-1-11" x="290.219989" y="69.103011"/>
-<use xlink:href="#glyph-1-12" x="293.025847" y="66.297153"/>
-<use xlink:href="#glyph-1-13" x="295.225166" y="64.097834"/>
-<use xlink:href="#glyph-1-14" x="297.424486" y="61.898514"/>
-<use xlink:href="#glyph-1-13" x="299.017266" y="60.305734"/>
-<use xlink:href="#glyph-1-14" x="301.216586" y="58.106414"/>
-<use xlink:href="#glyph-1-15" x="302.809366" y="56.513634"/>
-<use xlink:href="#glyph-1-16" x="305.615224" y="53.707776"/>
+<use xlink:href="#glyph-1-12" x="139.868003" y="87.117997"/>
+<use xlink:href="#glyph-1-33" x="142.067322" y="84.918678"/>
+<use xlink:href="#glyph-1-16" x="145.178915" y="81.807085"/>
 </g>
 <g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
-<use xlink:href="#glyph-1-10" x="310.625333" y="48.697667"/>
-<use xlink:href="#glyph-1-12" x="313.736926" y="45.586074"/>
-<use xlink:href="#glyph-1-33" x="315.936246" y="43.386754"/>
-<use xlink:href="#glyph-1-16" x="319.047839" y="40.275161"/>
-<use xlink:href="#glyph-1-14" x="322.159432" y="37.163568"/>
-<use xlink:href="#glyph-1-16" x="323.752212" y="35.570788"/>
-<use xlink:href="#glyph-1-17" x="326.863805" y="32.459195"/>
+<use xlink:href="#glyph-1-13" x="148.137641" y="78.848359"/>
+<use xlink:href="#glyph-1-14" x="150.33696" y="76.64904"/>
+<use xlink:href="#glyph-1-32" x="151.929741" y="75.056259"/>
+<use xlink:href="#glyph-1-21" x="156.560146" y="70.425854"/>
 </g>
-<path fill-rule="nonzero" fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 280.59025 0.00071875 C 280.59025 1.539781 279.34025 2.789781 277.797281 2.789781 C 276.258219 2.789781 275.008219 1.539781 275.008219 0.00071875 C 275.008219 -1.54225 276.258219 -2.788344 277.797281 -2.788344 C 279.34025 -2.788344 280.59025 -1.54225 280.59025 0.00071875 Z M 280.59025 0.00071875 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 277.797281 0.00071875 L 277.797281 31.180406 " transform="matrix(1, 0, 0, -1, 16.941, 147.989)"/>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-8" x="290.703413" y="104.961413"/>
-<use xlink:href="#glyph-1-25" x="293.815006" y="101.84982"/>
-<use xlink:href="#glyph-1-6" x="297.602175" y="98.062651"/>
-<use xlink:href="#glyph-1-7" x="301.083609" y="94.581217"/>
-<use xlink:href="#glyph-1-9" x="303.120198" y="92.544628"/>
+<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-10" x="160.963716" y="66.022284"/>
+<use xlink:href="#glyph-1-12" x="164.075309" y="62.910691"/>
+<use xlink:href="#glyph-1-33" x="166.274629" y="60.711371"/>
+<use xlink:href="#glyph-1-16" x="169.386222" y="57.599778"/>
+<use xlink:href="#glyph-1-14" x="172.497815" y="54.488185"/>
+<use xlink:href="#glyph-1-16" x="174.090596" y="52.895404"/>
+<use xlink:href="#glyph-1-17" x="177.202189" y="49.783811"/>
 </g>
+<path fill-rule="nonzero" fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 121.844156 0.000875 C 121.844156 1.539938 120.598062 2.789938 119.055094 2.789938 C 117.516031 2.789938 116.266031 1.539938 116.266031 0.000875 C 116.266031 -1.542094 117.516031 -2.788187 119.055094 -2.788187 C 120.598062 -2.788187 121.844156 -1.542094 121.844156 0.000875 Z M 121.844156 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 119.055094 0.000875 L 119.055094 17.008688 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-25" x="309.037649" y="86.627177"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="312.376078" y="83.288748"/>
-<use xlink:href="#glyph-1-0" x="316.533087" y="79.131739"/>
-</g>
-<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="320.167389" y="75.497437"/>
-<use xlink:href="#glyph-1-7" x="324.191256" y="71.47357"/>
-<use xlink:href="#glyph-1-9" x="326.227845" y="69.436981"/>
-<use xlink:href="#glyph-1-7" x="330.251712" y="65.413114"/>
-<use xlink:href="#glyph-1-36" x="332.288301" y="63.376525"/>
-<use xlink:href="#glyph-1-2" x="336.612972" y="59.051854"/>
+<use xlink:href="#glyph-1-6" x="136.686" y="141.323"/>
+<use xlink:href="#glyph-1-15" x="140.167434" y="137.841566"/>
+<use xlink:href="#glyph-1-17" x="142.973292" y="135.035708"/>
+<use xlink:href="#glyph-1-14" x="145.77915" y="132.22985"/>
+<use xlink:href="#glyph-1-34" x="147.371931" y="130.637069"/>
+<use xlink:href="#glyph-1-11" x="149.876985" y="128.132015"/>
+<use xlink:href="#glyph-1-18" x="152.682843" y="125.326157"/>
 </g>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-37" x="296.339" y="110.597"/>
-<use xlink:href="#glyph-1-4" x="301.408283" y="105.527717"/>
-<use xlink:href="#glyph-1-0" x="305.195452" y="101.740548"/>
+<use xlink:href="#glyph-1-12" x="156.174139" y="121.834861"/>
+<use xlink:href="#glyph-1-21" x="158.373459" y="119.635541"/>
+<use xlink:href="#glyph-1-10" x="160.878513" y="117.130487"/>
+<use xlink:href="#glyph-1-18" x="163.990106" y="114.018894"/>
+<use xlink:href="#glyph-1-14" x="165.582887" y="112.426113"/>
+<use xlink:href="#glyph-1-34" x="167.175667" y="110.833333"/>
+<use xlink:href="#glyph-1-11" x="169.680722" y="108.328278"/>
+<use xlink:href="#glyph-1-13" x="172.48658" y="105.52242"/>
+<use xlink:href="#glyph-1-14" x="174.685899" y="103.323101"/>
+<use xlink:href="#glyph-1-15" x="176.27868" y="101.73032"/>
+<use xlink:href="#glyph-1-16" x="179.084538" y="98.924462"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 161.531656 0.000875 C 161.531656 1.539938 160.281656 2.789938 158.742594 2.789938 C 157.203531 2.789938 155.953531 1.539938 155.953531 0.000875 C 155.953531 -1.542094 157.203531 -2.788187 158.742594 -2.788187 C 160.281656 -2.788187 161.531656 -1.542094 161.531656 0.000875 Z M 161.531656 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(32.499695%, 0%, 32.499695%)" stroke-opacity="1" stroke-miterlimit="10" d="M 158.742594 0.000875 L 158.742594 39.684469 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
+<use xlink:href="#glyph-1-27" x="177.284" y="119.558"/>
 </g>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-3" x="309.130557" y="97.805443"/>
-<use xlink:href="#glyph-1-4" x="313.489746" y="93.446254"/>
+<use xlink:href="#glyph-1-11" x="180.46463" y="116.37737"/>
+<use xlink:href="#glyph-1-23" x="183.270488" y="113.571512"/>
+<use xlink:href="#glyph-1-13" x="185.504326" y="111.337674"/>
 </g>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-25" x="319.170499" y="87.765501"/>
+<use xlink:href="#glyph-1-1" x="189.59723" y="107.24477"/>
 </g>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-1" x="322.508928" y="84.427072"/>
-<use xlink:href="#glyph-1-0" x="326.665937" y="80.270063"/>
+<use xlink:href="#glyph-1-9" x="193.305499" y="103.536501"/>
+<use xlink:href="#glyph-1-9" x="197.329366" y="99.512634"/>
 </g>
 <g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
-<use xlink:href="#glyph-1-9" x="330.300239" y="76.635761"/>
-<use xlink:href="#glyph-1-7" x="334.324106" y="72.611894"/>
-<use xlink:href="#glyph-1-9" x="336.360695" y="70.575305"/>
-<use xlink:href="#glyph-1-7" x="340.384562" y="66.551438"/>
-<use xlink:href="#glyph-1-36" x="342.421151" y="64.514849"/>
-<use xlink:href="#glyph-1-2" x="346.745822" y="60.190178"/>
-<use xlink:href="#glyph-1-8" x="350.902831" y="56.033169"/>
+<use xlink:href="#glyph-1-1" x="200.899562" y="95.942438"/>
+</g>
+<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
+<use xlink:href="#glyph-1-35" x="204.903703" y="91.938297"/>
+<use xlink:href="#glyph-1-28" x="208.92757" y="87.91443"/>
+</g>
+<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
+<use xlink:href="#glyph-1-25" x="214.978164" y="81.863836"/>
+</g>
+<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
+<use xlink:href="#glyph-1-1" x="218.316593" y="78.525407"/>
+<use xlink:href="#glyph-1-0" x="222.473602" y="74.368398"/>
+</g>
+<g fill="rgb(32.499695%, 0%, 32.499695%)" fill-opacity="1">
+<use xlink:href="#glyph-1-9" x="226.107904" y="70.734096"/>
+<use xlink:href="#glyph-1-7" x="230.13177" y="66.71023"/>
+<use xlink:href="#glyph-1-9" x="232.16836" y="64.67364"/>
+<use xlink:href="#glyph-1-7" x="236.192227" y="60.649773"/>
+<use xlink:href="#glyph-1-36" x="238.228816" y="58.613184"/>
+<use xlink:href="#glyph-1-2" x="242.553487" y="54.288513"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(0%, 50%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 201.219156 0.000875 C 201.219156 1.539938 199.969156 2.789938 198.426187 2.789938 C 196.887125 2.789938 195.637125 1.539938 195.637125 0.000875 C 195.637125 -1.542094 196.887125 -2.788187 198.426187 -2.788187 C 199.969156 -2.788187 201.219156 -1.542094 201.219156 0.000875 Z M 201.219156 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 50%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 198.426187 0.000875 L 198.426187 14.17275 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-37" x="216.11" y="144.212"/>
+<use xlink:href="#glyph-1-4" x="221.179283" y="139.142717"/>
+<use xlink:href="#glyph-1-0" x="224.966452" y="135.355548"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-3" x="228.901557" y="131.420443"/>
+<use xlink:href="#glyph-1-4" x="233.260746" y="127.061254"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-24" x="238.94643" y="121.37557"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-27" x="245.169617" y="115.152383"/>
+<use xlink:href="#glyph-1-26" x="248.803918" y="111.518082"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-38" x="255.01231" y="105.30969"/>
+<use xlink:href="#glyph-1-12" x="256.757959" y="103.564041"/>
+<use xlink:href="#glyph-1-15" x="258.957278" y="101.364722"/>
+<use xlink:href="#glyph-1-32" x="261.763136" y="98.558864"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-10" x="268.292057" y="92.029943"/>
+<use xlink:href="#glyph-1-11" x="271.40365" y="88.91835"/>
+<use xlink:href="#glyph-1-12" x="274.209508" y="86.112492"/>
+<use xlink:href="#glyph-1-13" x="276.408828" y="83.913172"/>
+<use xlink:href="#glyph-1-14" x="278.608147" y="81.713853"/>
+<use xlink:href="#glyph-1-13" x="280.200928" y="80.121072"/>
+<use xlink:href="#glyph-1-14" x="282.400247" y="77.921753"/>
+<use xlink:href="#glyph-1-15" x="283.993028" y="76.328972"/>
+<use xlink:href="#glyph-1-16" x="286.798886" y="73.523114"/>
+<use xlink:href="#glyph-1-21" x="289.910479" y="70.411521"/>
+<use xlink:href="#glyph-1-20" x="292.415533" y="67.906467"/>
+</g>
+<g fill="rgb(0%, 50%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-13" x="297.425642" y="62.896358"/>
+<use xlink:href="#glyph-1-11" x="299.624961" y="60.697039"/>
+<use xlink:href="#glyph-1-19" x="302.430819" y="57.891181"/>
+<use xlink:href="#glyph-1-18" x="305.542412" y="54.779588"/>
+<use xlink:href="#glyph-1-21" x="307.135193" y="53.186807"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 240.90275 0.000875 C 240.90275 1.539938 239.65275 2.789938 238.113687 2.789938 C 236.570719 2.789938 235.324625 1.539938 235.324625 0.000875 C 235.324625 -1.542094 236.570719 -2.788187 238.113687 -2.788187 C 239.65275 -2.788187 240.90275 -1.542094 240.90275 0.000875 Z M 240.90275 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(69.999695%, 34.999084%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 238.113687 0.000875 L 238.113687 36.852438 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-1" x="255.524" y="121.264"/>
+<use xlink:href="#glyph-1-2" x="259.681009" y="117.106991"/>
+<use xlink:href="#glyph-1-39" x="263.838019" y="112.949981"/>
+<use xlink:href="#glyph-1-40" x="267.995028" y="108.792972"/>
+<use xlink:href="#glyph-1-11" x="270.194348" y="106.593652"/>
+<use xlink:href="#glyph-1-12" x="273.000206" y="103.787794"/>
+<use xlink:href="#glyph-1-12" x="275.199525" y="101.588475"/>
+<use xlink:href="#glyph-1-11" x="277.398845" y="99.389155"/>
+</g>
+<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-41" x="280.056766" y="96.731234"/>
+<use xlink:href="#glyph-1-42" x="283.015492" y="93.772508"/>
+</g>
+<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-10" x="287.108396" y="89.679604"/>
+<use xlink:href="#glyph-1-11" x="290.219989" y="86.568011"/>
+<use xlink:href="#glyph-1-12" x="293.025847" y="83.762153"/>
+<use xlink:href="#glyph-1-13" x="295.225166" y="81.562834"/>
+<use xlink:href="#glyph-1-14" x="297.424486" y="79.363514"/>
+<use xlink:href="#glyph-1-13" x="299.017266" y="77.770734"/>
+<use xlink:href="#glyph-1-14" x="301.216586" y="75.571414"/>
+<use xlink:href="#glyph-1-15" x="302.809366" y="73.978634"/>
+<use xlink:href="#glyph-1-16" x="305.615224" y="71.172776"/>
+</g>
+<g fill="rgb(69.999695%, 34.999084%, 0%)" fill-opacity="1">
+<use xlink:href="#glyph-1-10" x="310.625333" y="66.162667"/>
+<use xlink:href="#glyph-1-12" x="313.736926" y="63.051074"/>
+<use xlink:href="#glyph-1-33" x="315.936246" y="60.851754"/>
+<use xlink:href="#glyph-1-16" x="319.047839" y="57.740161"/>
+<use xlink:href="#glyph-1-14" x="322.159432" y="54.628568"/>
+<use xlink:href="#glyph-1-16" x="323.752212" y="53.035788"/>
+<use xlink:href="#glyph-1-17" x="326.863805" y="49.924195"/>
+</g>
+<path fill-rule="nonzero" fill="rgb(64.99939%, 64.99939%, 64.99939%)" fill-opacity="1" stroke-width="0.3985" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(64.99939%, 64.99939%, 64.99939%)" stroke-opacity="1" stroke-miterlimit="10" d="M 359.961344 0.000875 C 359.961344 1.539938 358.711344 2.789938 357.168375 2.789938 C 355.629313 2.789938 354.379313 1.539938 354.379313 0.000875 C 354.379313 -1.542094 355.629313 -2.788187 357.168375 -2.788187 C 358.711344 -2.788187 359.961344 -1.542094 359.961344 0.000875 Z M 359.961344 0.000875 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<path fill="none" stroke-width="0.74721" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(64.99939%, 64.99939%, 64.99939%)" stroke-opacity="1" stroke-dasharray="2.98883 2.98883" stroke-miterlimit="10" d="M 357.168375 0.000875 L 357.168375 31.180563 " transform="matrix(1, 0, 0, -1, 16.941, 165.454)"/>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-8" x="375.709" y="128.062"/>
+<use xlink:href="#glyph-1-25" x="378.820593" y="124.950407"/>
+<use xlink:href="#glyph-1-6" x="382.607762" y="121.163238"/>
+<use xlink:href="#glyph-1-7" x="386.089196" y="117.681804"/>
+<use xlink:href="#glyph-1-9" x="388.125785" y="115.645215"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-25" x="394.048168" y="109.722832"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-1" x="397.381665" y="106.389335"/>
+<use xlink:href="#glyph-1-0" x="401.538674" y="102.232326"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-9" x="405.172976" y="98.598024"/>
+<use xlink:href="#glyph-1-7" x="409.196843" y="94.574157"/>
+<use xlink:href="#glyph-1-9" x="411.233432" y="92.537568"/>
+<use xlink:href="#glyph-1-7" x="415.257299" y="88.513701"/>
+<use xlink:href="#glyph-1-36" x="417.293888" y="86.477112"/>
+<use xlink:href="#glyph-1-2" x="421.618559" y="82.152441"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-24" x="427.674084" y="76.096916"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-37" x="433.89727" y="69.87373"/>
+<use xlink:href="#glyph-1-4" x="438.966553" y="64.804447"/>
+<use xlink:href="#glyph-1-0" x="442.753722" y="61.017278"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-3" x="446.688827" y="57.082173"/>
+<use xlink:href="#glyph-1-4" x="451.048016" y="52.722984"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-25" x="456.733701" y="47.037299"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-1" x="460.067198" y="43.703802"/>
+<use xlink:href="#glyph-1-0" x="464.224208" y="39.546792"/>
+</g>
+<g fill="rgb(59.999084%, 59.999084%, 59.999084%)" fill-opacity="1">
+<use xlink:href="#glyph-1-9" x="467.858509" y="35.912491"/>
+<use xlink:href="#glyph-1-7" x="471.882376" y="31.888624"/>
+<use xlink:href="#glyph-1-9" x="473.918965" y="29.852035"/>
+<use xlink:href="#glyph-1-7" x="477.942832" y="25.828168"/>
+<use xlink:href="#glyph-1-36" x="479.979421" y="23.791579"/>
+<use xlink:href="#glyph-1-2" x="484.304092" y="19.466908"/>
+<use xlink:href="#glyph-1-8" x="488.461101" y="15.309899"/>
 </g>
 </svg>

--- a/content/post/2026/07/pg-since-11/fig-partition-timeline.tex
+++ b/content/post/2026/07/pg-since-11/fig-partition-timeline.tex
@@ -7,9 +7,9 @@
 \colorlet{cP}{orange!70!black}
 \colorlet{cO}{violet!65!black}
 
-\draw[black!25, line width=0.8pt, -latex] (-0.3,0) -- (10.6,0);
+\draw[black!25, line width=0.8pt, -latex] (-0.3,0) -- (13.6,0);
 
-\foreach \ver in {10,11,12,13,14,15,16,17} {
+\foreach \ver in {10,11,12,13,14,15,16,17,18,19} {
   \pgfmathsetmacro{\xpos}{(\ver - 10) * 1.4}
   \draw[black!30, thin] (\xpos,-0.12) -- (\xpos,0.12);
   \node[font=\tiny, black!50, anchor=north] at (\xpos,-0.16) {\textbf{PG\,\ver}};
@@ -63,12 +63,12 @@
 \node[rotate=45, anchor=south west, font=\scriptsize, cP]
   at (8.46,1.34) {ANY(array) partition pruning};
 
-%% PG 17 — SPLIT PARTITION + MERGE PARTITIONS (h=1.1, two lines)
-\filldraw[cO] (9.8,0) circle (2.8pt);
-\draw[cO, line width=0.75pt] (9.8,0) -- (9.8,1.1);
-\node[rotate=45, anchor=south west, font=\scriptsize, cO, align=left]
-  at (9.86,1.14) {SPLIT PARTITION\\MERGE PARTITIONS};
+%% PG 19 — SPLIT PARTITION + MERGE PARTITIONS (tentative, dashed, h=1.1)
+\filldraw[black!35] (12.6,0) circle (2.8pt);
+\draw[black!35, line width=0.75pt, dashed] (12.6,0) -- (12.6,1.1);
+\node[rotate=45, anchor=south west, font=\scriptsize, black!40, align=left]
+  at (12.66,1.14) {SPLIT PARTITION · MERGE PARTITIONS};
 
 \end{tikzpicture}
-\caption{Declarative partitioning milestones, PG\,10–PG\,17.}
+\caption{Declarative partitioning milestones, PG\,10–PG\,19.}
 \end{figure}

--- a/content/post/2026/07/pg-since-11/index.md
+++ b/content/post/2026/07/pg-since-11/index.md
@@ -528,28 +528,84 @@ PostgreSQL 17 ships a built-in `C.UTF-8` collation (also accessible as
 - **Immutable** — the sort order is part of the PostgreSQL release; it never changes on an OS upgrade.
 - **Fast** — it avoids locale-aware comparison functions and is roughly as fast as the classic `C` locale.
 
+The built-in locale is named `C.UTF-8` in `BUILTIN_LOCALE`, but the
+corresponding SQL collation is `pg_c_utf8`.  Creating a database with it
+requires `TEMPLATE template0` when the cluster default is `libc` (which it
+is unless you changed it at `initdb` time):
+
 ```sql
--- Create a database with the portable built-in collation
-create database myapp
-    encoding      'UTF8'
-    locale_provider builtin
-    builtin_locale 'C.UTF-8';
-
--- Or apply it per-column on an existing table
-alter table articles
-    alter column title type text collate "C.UTF-8";
-
--- Or per-expression in a query
-select title from articles order by title collate "C.UTF-8";
+-- cluster default is libc:
+select datname, datlocprovider, datlocale
+  from pg_database
+ where datname = 'template1';
 ```
 
-Use `C.UTF-8` whenever you need reproducible `ORDER BY` across environments:
-multi-region deployments, CI pipelines that compare sort order against a
-fixture, or logical replicas on different OS versions.  Its code-point sort
-order is less human-friendly than a language-aware ICU collation (accented
-characters sort after all ASCII letters), so prefer a named ICU collation for
-end-user-facing sorted lists and save `C.UTF-8` for internal keys and system
-tables where stability matters more than linguistic naturalness.
+```results
+  datname  | datlocprovider | datlocale
+-----------+----------------+-----------
+ template1 | c              |
+```
+
+```sql
+-- create a database with the portable built-in collation
+-- template0 is required when switching locale provider
+create database myapp
+    encoding        'UTF8'
+    locale_provider builtin
+    builtin_locale  'C.UTF-8'
+    template        template0;
+```
+
+```results
+CREATE DATABASE
+```
+
+```sql
+-- reconnect and confirm
+select datname, datlocprovider, datlocale
+  from pg_database
+ where datname = 'myapp';
+```
+
+```results
+ datname | datlocprovider | datlocale
+---------+----------------+-----------
+ myapp   | b              | C.UTF-8
+```
+
+```sql
+-- default ORDER BY now uses pg_c_utf8: code-point order
+-- (uppercase before lowercase; ASCII before extended Unicode)
+select word from words order by word;
+```
+
+```results
+   word
+----------
+ Azure
+ azure
+ banana
+ Ångström
+ ångström
+```
+
+```sql
+-- apply per-column on an existing database
+alter table articles
+    alter column title type text collate pg_c_utf8;
+
+-- or per-expression in a query
+select title from articles order by title collate pg_c_utf8;
+```
+
+Use `pg_c_utf8` whenever you need reproducible `ORDER BY` across
+environments: multi-region deployments, CI pipelines that compare sort order
+against a fixture, or logical replicas on different OS versions.  Its
+code-point sort order is less human-friendly than a language-aware ICU
+collation (accented characters sort after all ASCII letters), so prefer a
+named ICU collation for end-user-facing sorted lists and save `pg_c_utf8` for
+internal keys and system tables where stability matters more than linguistic
+naturalness.
 
 ### Incremental Sort (PG 13)
 

--- a/content/post/2026/07/pg-since-11/index.md
+++ b/content/post/2026/07/pg-since-11/index.md
@@ -66,7 +66,7 @@ user-visible changes from the official release notes.
 | PG 11 | Oct 2018 | 180 | Stored procedures (`CREATE PROCEDURE` / `CALL`), JIT compilation, covering indexes (`INCLUDE`) |
 | PG 12 | Oct 2019 | 200 | Generated columns, JSON path language (`@?` / `@@`), CTE inlining, `REINDEX CONCURRENTLY` |
 | PG 13 | Sep 2020 | 150 | Incremental sort, B-tree deduplication, `gen_random_uuid()` built-in |
-| PG 14 | Sep 2021 | 200 | Multirange types, JSONB subscript syntax (`doc['key']`), `FETCH … WITH TIES`, SEARCH/CYCLE |
+| PG 14 | Sep 2021 | 200 | Multirange types, JSONB subscript syntax (`doc['key']`), SEARCH/CYCLE in CTEs |
 | PG 15 | Oct 2022 | 180 | SQL `MERGE`, `NULLS NOT DISTINCT`, row/column filters in logical replication |
 | PG 16 | Sep 2023 | 150 | Logical replication on standbys, `pg_stat_io`, `ANY_VALUE()`, `IS JSON` predicate |
 | PG 17 | Sep 2024 | 180 | `JSON_TABLE()`, incremental backups, `COPY ON_ERROR IGNORE`, built-in `C.UTF-8` collation |
@@ -85,7 +85,7 @@ exist.  [There is a longer write-up on SQL and AI here](https://theartofpostgres
 
 ## Query execution
 
-### Window frame GROUPS mode and EXCLUDE (PG 11 / PG 14)
+### Window frame GROUPS mode and EXCLUDE (PG 11)
 
 The `ROWS` frame mode counts physical rows; `RANGE` counts by value distance.
 PostgreSQL 11 added a third mode, `GROUPS`, which counts *peer groups* —
@@ -94,8 +94,9 @@ unit for ranked or tied data.
 
 {{< image src="fig-window-frame-spec.svg" title="Three window frame specifications shown on a 7-row result set: UNBOUNDED PRECEDING to CURRENT ROW (running total), 1 PRECEDING to 1 FOLLOWING (sliding window), and CURRENT ROW to UNBOUNDED FOLLOWING (remaining total)." >}}
 
-PostgreSQL 14 added the `EXCLUDE` sub-clause, which removes specific rows
-from the frame — `EXCLUDE CURRENT ROW`, `EXCLUDE TIES`, or `EXCLUDE GROUP`.
+PostgreSQL 11 also added the `EXCLUDE` sub-clause as part of the same
+SQL:2011 compliance push — `EXCLUDE CURRENT ROW`, `EXCLUDE TIES`, or
+`EXCLUDE GROUP` — which removes specific rows from the frame.
 `EXCLUDE TIES` keeps the current row in the frame but removes other rows that
 share the same ORDER BY value.  A single race is a bad showcase — every
 scoring position has a unique points value, so no ties ever appear.  The 2007
@@ -741,20 +742,6 @@ PG 11.  The highlights, in version order:
   constraint already exists, eliminating the full-table scan.
 - **PG 15** — `MERGE` statement support on partitioned tables; foreign key
   references *from* a partitioned table.
-- **PG 17** — `SPLIT PARTITION` and `MERGE PARTITIONS` for online
-  restructuring without recreating the table.
-
-```sql
--- Split a year partition into quarters (PG 17)
-alter table measurements
-    split partition measurements_2024
-    into (
-        partition measurements_2024_q1
-            for values from ('2024-01-01') to ('2024-04-01'),
-        partition measurements_2024_rest
-            for values from ('2024-04-01') to ('2025-01-01')
-    );
-```
 
 ---
 
@@ -929,10 +916,13 @@ extend operations broken down by backend type (client backend, autovacuum,
 checkpointer) and I/O context (heap, index, WAL).  The missing piece for
 diagnosing I/O-bound workloads without reaching for OS-level tools.
 
-**ICU as default locale provider (PG 15)** — new clusters created with PG 15+
-default to ICU for locale-aware collation, giving stable, OS-independent
-sort behaviour for non-C locales — a complement to the built-in `C.UTF-8`
-collation for cases where linguistic sort order matters.
+**ICU locale provider at cluster level (PG 15)** — before PG 15, ICU
+collations could only be attached to individual columns via an explicit
+`COLLATE` clause; `libc` was the only option at `initdb` or `CREATE DATABASE`
+time.  PG 15 lifted that restriction: you can now choose ICU as the
+locale provider for the whole cluster or database, getting stable,
+OS-independent sort behaviour for non-C locales.  The default remains
+`libc` unless you opt in.
 
 **Logical replication: row and column filters (PG 15)** — publications can
 now include a `WHERE` clause to replicate only matching rows and a column

--- a/content/post/2026/07/pg-since-11/index.md
+++ b/content/post/2026/07/pg-since-11/index.md
@@ -728,9 +728,9 @@ create table customer (
 );
 ```
 
-### Partition improvements (PG 12–17)
+### Partition improvements (PG 12–19)
 
-{{< image src="fig-partition-timeline.svg" title="Declarative partitioning milestones, PG 10–17." >}}
+{{< image src="fig-partition-timeline.svg" title="Declarative partitioning milestones, PG 10–19." >}}
 
 Declarative partitioning has received a steady stream of improvements since
 PG 11.  The highlights, in version order:
@@ -742,6 +742,8 @@ PG 11.  The highlights, in version order:
   constraint already exists, eliminating the full-table scan.
 - **PG 15** — `MERGE` statement support on partitioned tables; foreign key
   references *from* a partitioned table.
+- **PG 19 (planned)** — `SPLIT PARTITION` and `MERGE PARTITIONS` for online
+  restructuring without recreating the table.
 
 ---
 

--- a/content/post/2026/07/pg-since-11/index.md
+++ b/content/post/2026/07/pg-since-11/index.md
@@ -574,9 +574,11 @@ select datname, datlocprovider, datlocale
 ```
 
 ```sql
--- default ORDER BY now uses pg_c_utf8: code-point order
--- (uppercase before lowercase; ASCII before extended Unicode)
-select word from words order by word;
+-- code-point order: uppercase before lowercase, ASCII before extended Unicode
+-- pg_c_utf8 works in any database, regardless of its own locale provider
+select word
+  from (values ('ångström'), ('banana'), ('Ångström'), ('Azure'), ('azure')) as t(word)
+ order by word collate pg_c_utf8;
 ```
 
 ```results
@@ -590,12 +592,9 @@ select word from words order by word;
 ```
 
 ```sql
--- apply per-column on an existing database
+-- apply per-column on an existing table
 alter table articles
     alter column title type text collate pg_c_utf8;
-
--- or per-expression in a query
-select title from articles order by title collate pg_c_utf8;
 ```
 
 Use `pg_c_utf8` whenever you need reproducible `ORDER BY` across


### PR DESCRIPTION
Corrections prompted by Postgres Weekly pre-publication review.

**EXCLUDE sub-clause (PG 11, not PG 14)**
`EXCLUDE CURRENT ROW`, `EXCLUDE TIES`, and `EXCLUDE GROUP` were added in PG 11 as part of the SQL:2011 window framing compliance push — same release as `GROUPS` mode. Section heading and body text corrected.

**FETCH FIRST WITH TIES removed from PG 14 headline**
It is a PG 13 feature. The dedicated section was already correct; the release table row was not.

**SPLIT/MERGE PARTITIONS: PG 17 → PG 19 (planned)**
These were in the PG 17 betas but dropped before RC. Added as a planned PG 19 item in the bullet list and updated the partition timeline diagram (dashed node, extended axis to PG 19).

**ICU locale provider (PG 15): not the default**
PG 15 made ICU *selectable* at `CREATE DATABASE` time (previously ICU was column-level only). libc remains the default. The Beyond SQL blurb said 'new clusters default to ICU' — corrected.

**Bonus fixes found while Docker-testing the C.UTF-8 section:**
- `CREATE DATABASE` with a non-default locale provider requires `TEMPLATE template0`
- The collation name for expressions is `pg_c_utf8`, not `"C.UTF-8"` (which is the `BUILTIN_LOCALE` identifier)
- Sort example rewritten to use inline `VALUES` — runnable without creating a table
- Added captured output from PG 17.10