### PR TITLE
CI: fix Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0          # full history for .Lastmod / .GitInfo
@@ -40,7 +40,7 @@ jobs:
         # No --buildFuture: posts dated in the future stay queued until their
         # date passes and the next scheduled run picks them up.
         run: hugo --minify --gc --baseURL "https://tapoueh.org/"
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs
 
@@ -52,4 +52,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
actions/checkout@v4, actions/upload-pages-artifact@v3, and actions/deploy-pages@v4 all target Node.js 20, which GitHub Actions is deprecating and currently force-running on Node.js 24.

Bumps to the latest majors that ship node24 runtimes:
- actions/checkout v4 → v7 (node24)
- actions/upload-pages-artifact v3 → v5 (composite, now pulls in actions/upload-artifact@v7 which is node24)
- actions/deploy-pages v4 → v5 (node24)

peaceiris/actions-hugo is left at v3 — it's a composite action, not the source of the warning.