### PR TITLE
SQL/PGQ was reverted from PostgreSQL 19

### DIFF
--- a/content/post/2026/07/pg-since-11/index.md
+++ b/content/post/2026/07/pg-since-11/index.md
@@ -799,7 +799,7 @@ PG 11.  The highlights, in version order:
   references *from* a partitioned table.
 - **PG 19 — withdrawn.** `SPLIT PARTITION` and `MERGE PARTITIONS` were
   committed for PG 19 and then [reverted on 27 August
-  2026](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3e8bcc864),
+  2026](https://git.postgresql.org/cgit/postgresql.git/commit/?id=3e8bcc8644feaa9ca1cc954197b6994817af4290),
   the second time this feature has been pulled late in a cycle. I go through
   what went wrong, with reproductions, in [Getting Ready for PostgreSQL
   19](/blog/2026/09/getting-ready-for-postgresql-19/).

--- a/content/post/2026/09/pg19-preview/index.md
+++ b/content/post/2026/09/pg19-preview/index.md
@@ -373,7 +373,7 @@ statement instead of the detach/recreate/reattach dance. I wrote it, ran the
 queries against Beta 3, and drew a diagram for it.
 
 Then, on August 27, [Alexander Korotkov reverted the whole
-feature](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3e8bcc864)
+feature](https://git.postgresql.org/cgit/postgresql.git/commit/?id=3e8bcc8644feaa9ca1cc954197b6994817af4290)
 from the PostgreSQL 19 branch. I am leaving the section in, because how that
 decision got made is more interesting than the feature would have been:
 
@@ -770,7 +770,7 @@ actually lives, rather than in a comment above the query.
 **Update, 7 September 2026.** This section described a feature that is no
 longer in PostgreSQL 19. On the evening of the 7th, Peter Eisentraut —
 SQL/PGQ's own author — [reverted the whole
-thing](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=2b9e1aff4)
+thing](https://git.postgresql.org/cgit/postgresql.git/commit/?id=b1f106c80cbeb18d3a0219994d98a51a6eca8ede)
 from the release branch, 47 commits of it. I published this on the 3rd.
 Everything below ran on Beta 3 and is what the feature did; none of it is
 what PostgreSQL 19 will ship.

--- a/content/post/2026/09/pg19-preview/index.md
+++ b/content/post/2026/09/pg19-preview/index.md
@@ -763,10 +763,53 @@ actually lives, rather than in a comment above the query.
 
 ---
 
-## SQL/PGQ: graph patterns over the tables you already have
+## SQL/PGQ: withdrawn from 19, four days after this went out
 
-PostgreSQL 19 implements [SQL/PGQ](https://www.iso.org/standard/79473.html),
-Part 16 of the SQL standard, which lets you query relational tables using
+**Update, 7 September 2026.** This section described a feature that is no
+longer in PostgreSQL 19. On the evening of the 7th, Peter Eisentraut —
+SQL/PGQ's own author — [reverted the whole
+thing](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=2b9e1aff4)
+from the release branch, 47 commits of it. I published this on the 3rd.
+Everything below ran on Beta 3 and is what the feature did; none of it is
+what PostgreSQL 19 will ship.
+
+I am leaving it, for the same reason the `MERGE PARTITIONS` section above
+is still here, and because two independent withdrawals from one release
+cycle say something the working feature would not have.
+
+The call came from Melanie Plageman writing for the Release Management
+Team, in [the thread on catalog representation and `pg_dump`
+support](https://www.postgresql.org/message-id/CAAKRu_bEtjWYWhYxSo0o_t3DaZYRQd5PkC0abA0g9Mp4%2BovH0w%40mail.gmail.com),
+over four unresolved problems. `DROP TABLE ... CASCADE` left orphaned
+label and property metadata behind — phantom rows in `information_schema`
+that could make later alterations fail and, worse, "render the graph
+undumpable/unrestorable". Labels and properties were scoped globally
+rather than per-label, so a view over a `GRAPH_TABLE` could become
+"silently unqueryable" after a property was dropped from one element while
+still existing on another, a case the standard does not settle. There were
+open questions about whether property graphs should have `pg_class` entries
+at all. And there was an unresolved `pg_dump` dependency loop when a
+materialized view queries a `GRAPH_TABLE`.
+
+The RMT's argument was about time, not merit: reverting "would take off the
+time pressure now and would make it easier to fix these things properly in
+20 without having to be burdened by backwards compatibility and
+backpatching." Note what that has in common with the partitions story — both
+features were pulled over what an object *carries* and how it is *dumped*,
+not over whether the headline feature worked. It worked. I ran it.
+
+One practical note, and it is the same trap as before: at the time of
+writing the docs site still serves
+[`ddl-property-graphs.html`](https://www.postgresql.org/docs/19/ddl-property-graphs.html)
+because it has not rebuilt yet. The release notes, to the project's credit,
+were corrected in the revert commit itself this time.
+
+The rest of this section is preserved as written.
+
+---
+
+PostgreSQL 19 implemented [SQL/PGQ](https://www.iso.org/standard/79473.html),
+Part 16 of the SQL standard, which let you query relational tables using
 graph pattern syntax. It is worth being clear about what that does and does
 not mean. A property graph is *not* a new storage engine and not a copy of
 your data: `CREATE PROPERTY GRAPH` behaves like `CREATE VIEW`, recording a
@@ -888,10 +931,11 @@ round-up](/blog/2026/07/sql-improvements-in-postgresql-1118-a-personal-selection
 that map of everywhere you can drive from France in four hops is a recursive
 CTE, and a good one.
 
-### Why this is the right amount to ship
+### Why it was still the right amount to ship
 
 It would be easy to read "no variable-length paths" as PGQ arriving
-half-finished. I would read it the other way round.
+half-finished. I would read it the other way round — and the revert does
+not change that reading, it sharpens it.
 
 What landed is the part that is tedious, invasive and hard to change later:
 five new system catalogs, a parser that understands the full pattern grammar,
@@ -909,12 +953,22 @@ process looks like when the engineers decide what is ready, rather than a
 calendar or a feature-comparison table. Oracle 23ai shipped SQL/PGQ first, and
 PostgreSQL is not racing it.
 
-What you get today is real: property graphs are declared over tables you
-already have, cost nothing to maintain, and let you write a pattern instead of
-a join chain — with the standard's syntax, so what you learn now is what you
-will use later. The rest builds on this, one release at a time. That is how
-PostgreSQL has always gotten where it is going, and it is why the pieces still
-fit together twenty years on.
+What the revert adds is that the same standard gets applied to the
+foundation, not only to the parts left out of it. The query layer worked —
+that is the part I demonstrated, and it is the part a release under
+commercial pressure would have shipped. What was not finished was catalog
+housekeeping: what happens to a label when a `CASCADE` sweeps past it,
+whether `pg_dump` can put the thing back. Nobody writes a launch blog post
+about `pg_dump` round-tripping. It is exactly the sort of unglamorous
+correctness that gets deferred when a date is promised, and exactly what
+you are relying on the day you restore a backup.
+
+Two features pulled from one release for that reason is not a project
+struggling to ship. It is a project that would rather be a year late than
+be wrong in your database, twice in the same cycle, from people who had
+every incentive to let their own work through. The rest builds on this, one
+release at a time. That is how PostgreSQL has always gotten where it is
+going, and it is why the pieces still fit together twenty years on.
 
 ---
 

--- a/content/post/2026/09/pg19-preview/index.md
+++ b/content/post/2026/09/pg19-preview/index.md
@@ -763,6 +763,8 @@ actually lives, rather than in a comment above the query.
 
 ---
 
+<div id="sqlpgq-graph-patterns-over-the-tables-you-already-have"></div>
+
 ## SQL/PGQ: withdrawn from 19, four days after this went out
 
 **Update, 7 September 2026.** This section described a feature that is no


### PR DESCRIPTION
Peter Eisentraut reverted SQL/PGQ — his own feature — from PostgreSQL 19 on the evening of **7 September** ([`b1f106c80`](https://git.postgresql.org/cgit/postgresql.git/commit/?id=b1f106c80cbeb18d3a0219994d98a51a6eca8ede)), 47 commits of it, along with the release-note entries and the ref pages. "Getting Ready for PostgreSQL 19" published on the **3rd** with a full section presenting it as shipping.

Merging deploys immediately.

## Approach

Kept rather than deleted, the same treatment MERGE PARTITIONS got: a dated correction at the top of the section, the Beta 3 material preserved below it as what the feature did. Two withdrawals from one release cycle is a better story than either feature would have been.

## Why it was reverted

From the [RMT thread](https://www.postgresql.org/message-id/CAAKRu_bEtjWYWhYxSo0o_t3DaZYRQd5PkC0abA0g9Mp4%2BovH0w%40mail.gmail.com), Melanie Plageman writing for the Release Management Team:

- `DROP TABLE ... CASCADE` left orphaned label and property metadata — phantom `information_schema` rows that could make later alterations fail and "render the graph undumpable/unrestorable"
- labels and properties scoped globally rather than per-label, so a view over a `GRAPH_TABLE` could become "silently unqueryable"
- open questions about whether property graphs should have `pg_class` entries at all
- an unresolved `pg_dump` dependency loop when a materialized view queries a `GRAPH_TABLE`

The argument was time, not merit: better to fix it properly in 20 than carry backwards compatibility for a rushed 19.

## The closing section

That needed the most rewriting, since it praised the scope of something that then did not ship. It now makes the sharper point the revert actually supports: the query layer worked — that is what I demonstrated, and what a release under commercial pressure ships. What was unfinished was catalog housekeeping: what a `CASCADE` does to a label, whether `pg_dump` can put the graph back. Nobody writes a launch post about `pg_dump` round-tripping, and it is exactly what you depend on the day you restore a backup.

## The old anchor still works

Renaming the heading changed its generated id, and the article has been published and syndicated for five days, so anything that deep-linked `#sqlpgq-graph-patterns-over-the-tables-you-already-have` would land on the page without jumping — a failure that looks like nothing happening.

An empty `div` carrying the old id sits immediately above the heading. A `div` rather than a `span` because goldmark wraps inline HTML in a paragraph, and that paragraph's margins open a visible gap; a div passes through as an HTML block and takes no space. Verified in the built page: both ids resolve, the heading still renders as an `h2`, and the table of contents points at the new one.

## Also

Commit links now go through cgit rather than gitweb, with full 40-character ids since these are permanent links in published articles. That touches the MERGE/SPLIT link in the PG 11–18 round-up too, which points at the same commit. Both URLs verified to resolve. Older posts keep their gitweb links; they are ten to fifteen years old and left alone.

Prose and links only — no SQL block or captured output changed.